### PR TITLE
Expose HTTP server to support calling `close`

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -52,7 +52,7 @@ var app = function (hostname, port, directory, silent, indexDocument, errorDocum
 
   return {
     serve: function (done) {
-      app.listen(port, hostname, function (err) {
+      return app.listen(port, hostname, function (err) {
         return done(err, hostname, port, directory);
       }).on('error', function (err) {
         return done(err);


### PR DESCRIPTION
In order to support cleanly shutting down the express app after calling `run`, the result of calling express's `listen` method must be returned. This adds support for:

```javascript
var server = s3rver
      .setHostname('localhost')
      .setPort(4568)
      .setDirectory(S3_DIR)
      .setSilent(true)
      .run(function (err, host, port) {

      });

server.close(function(err) {

});
```

This is a pretty essential feature during testing.