### PR TITLE
listObjects compatibility with Windows OS

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -92,12 +92,12 @@ var FileStore = function (rootDirectory) {
   };
 
   var getObjects = function (bucket, options, done) {
-    var bucketPath = getBucketPath(bucket.name);
+    var bucketPath = getBucketPath(bucket.name).replace(/\\/g, '/');
     var matches = [];
     var keys = utils.walk(bucketPath);
     var filteredKeys = _.filter(keys, function (file) {
       if (options.prefix) {
-        var key = file.replace(bucketPath + '/', '');
+        var key = file.replace(/\\/g, '/').replace(bucketPath + '/', '');
         var match = (key.substring(0, options.prefix.length) === options.prefix);
         return match;
       }

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -104,6 +104,7 @@ var FileStore = function (rootDirectory) {
       return true;
     });
     async.eachSeries(filteredKeys, function (key, callback) {
+      key = key.replace(/\\/g, '/');
         fs.readFile(path.join(key, METADATA_FILE), function (err, data) {
           if (data) {
             matches.push(buildS3ObjectFromMetaDataFile(key.replace(bucketPath + '/', ''), data));

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -14,7 +14,7 @@ var FileStore = function (rootDirectory) {
       S3Object      = require('./models/s3-object');
 
   var getBucketPath = function (bucketName) {
-    return path.join(rootDirectory, bucketName);
+    return path.join(rootDirectory, bucketName).replace(/\\/g, '/');
   };
 
   var getBucket = function (bucketName, done) {
@@ -92,7 +92,7 @@ var FileStore = function (rootDirectory) {
   };
 
   var getObjects = function (bucket, options, done) {
-    var bucketPath = getBucketPath(bucket.name).replace(/\\/g, '/');
+    var bucketPath = getBucketPath(bucket.name);
     var matches = [];
     var keys = utils.walk(bucketPath);
     var filteredKeys = _.filter(keys, function (file) {


### PR DESCRIPTION
This is a fix for issue #6.

On the Windows OS, file paths use the backslash to delimit each folder while object keys expect the forward slash. When walking file storage items, we explicitly convert the slashes so they match our expected `object key` format.

I have run this change through this projects unit tests as well as my own and they all pass now.