### PR TITLE
Fix program option --indexDocument

### DIFF
--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -10,7 +10,7 @@ program.version(version, '--version');
 program.option('-h, --hostname [value]', 'Set the host name or ip for the server', 'localhost')
   .option('-p, --port <n>', 'Set the port of the http server', 4568)
   .option('-s, --silent', 'Suppress log messages', false)
-  .option('-i, --indexDocumement', 'Index Document for Static Web Hosting', '')
+  .option('-i, --indexDocument [value]', 'Index Document for Static Web Hosting', '')
   .option('-e, --errorDocument', 'Custom Error Document for Static Web Hosting', '')
   .option('-d, --directory [path]', 'Data directory')
   .parse(process.argv);


### PR DESCRIPTION
Fix typo and missing option value.

Not sure if `[value]` or `<value>` would be preferred (?).
