### PR TITLE
Fix ETag field format in HTTP response

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -15,7 +15,7 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument) 
 
   var buildResponse = function (req, res, status, object, data) {
     res.header('Access-Control-Allow-Origin', '*');
-    res.header('Etag', object.md5);
+    res.header('Etag', '"' + object.md5 + '"');
     res.header('Last-Modified', new Date(object.modifiedDate).toUTCString());
     res.header('Content-Type', object.contentType);
 
@@ -264,7 +264,7 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument) 
             return buildXmlResponse(res, 500, template);
           }
           logger.info('Stored object "%s" in bucket "%s" successfully', req.params.key, req.bucket.name);
-          res.header('ETag', key.md5);
+          res.header('ETag', '"' + key.md5 + '"');
           return res.status(200).end();
         });
       }

--- a/lib/xml-template-builder.js
+++ b/lib/xml-template-builder.js
@@ -9,7 +9,7 @@ var xml = function () {
         Contents: {
           Key: item.key,
           LastModified: item.modifiedDate,
-          ETag: item.md5,
+          ETag: '"' + item.md5 + '"',
           Size: item.size,
           StorageClass: 'Standard',
           Owner: {
@@ -153,7 +153,7 @@ var xml = function () {
       return jstoxml.toXML({
         CopyObjectResult: {
           LastModified: item.modifiedDate,
-          ETag: item.md5
+          ETag: '"' + item.md5 + '"'
         }
       }, {
         header: true,

--- a/test/test.js
+++ b/test/test.js
@@ -135,7 +135,7 @@ describe('S3rver Tests', function () {
   it('should store a text object in a bucket', function (done) {
     var params = {Bucket: buckets[0], Key: 'text', Body: 'Hello!'};
     s3Client.putObject(params, function (err, data) {
-      /[a-fA-F0-9]{32}/.test(data.ETag).should.equal(true);
+      /"[a-fA-F0-9]{32}"/.test(data.ETag).should.equal(true);
       if (err) {
         return done(err);
       }
@@ -150,7 +150,7 @@ describe('S3rver Tests', function () {
       }
     };
     s3Client.putObject(params, function (err, data) {
-      /[a-fA-F0-9]{32}/.test(data.ETag).should.equal(true);
+      /"[a-fA-F0-9]{32}"/.test(data.ETag).should.equal(true);
       if (err) {
         return done(err);
       }
@@ -182,7 +182,7 @@ describe('S3rver Tests', function () {
         ContentLength: data.length
       };
       s3Client.putObject(params, function (err, data) {
-        /[a-fA-F0-9]{32}/.test(data.ETag).should.equal(true);
+        /"[a-fA-F0-9]{32}"/.test(data.ETag).should.equal(true);
         if (err) {
           return done(err);
         }
@@ -226,7 +226,7 @@ describe('S3rver Tests', function () {
       CopySource: '/' + buckets[0] + '/image'
     };
     s3Client.copyObject(params, function (err, data) {
-      /[a-fA-F0-9]{32}/.test(data.ETag).should.equal(true);
+      /"[a-fA-F0-9]{32}"/.test(data.ETag).should.equal(true);
       if (err) {
         return done(err);
       }
@@ -268,7 +268,7 @@ describe('S3rver Tests', function () {
       if (err) {
         return done(err);
       }
-      /[a-fA-F0-9]{32}/.test(data.ETag).should.equal(true);
+      /"[a-fA-F0-9]{32}"/.test(data.ETag).should.equal(true);
       done();
     });
   });
@@ -280,7 +280,7 @@ describe('S3rver Tests', function () {
         if (err) {
           return done(err);
         }
-        object.ETag.should.equal(md5(data));
+        object.ETag.should.equal('"' + md5(data) + '"');
         object.ContentLength.should.equal(data.length.toString());
         object.ContentType.should.equal('image/jpeg');
         done();
@@ -295,7 +295,7 @@ describe('S3rver Tests', function () {
         if (err) {
           return done(err);
         }
-        object.ETag.should.equal(md5(data));
+        object.ETag.should.equal('"' + md5(data) + '"');
         object.ContentLength.should.equal(data.length.toString());
         object.ContentType.should.equal('image/jpeg');
         done();
@@ -404,7 +404,7 @@ describe('S3rver Tests', function () {
   it('should upload a text file to a multi directory path', function (done) {
     var params = {Bucket: buckets[0], Key: 'multi/directory/path/text', Body: 'Hello!'};
     s3Client.putObject(params, function (err, data) {
-      /[a-fA-F0-9]{32}/.test(data.ETag).should.equal(true);
+      /"[a-fA-F0-9]{32}"/.test(data.ETag).should.equal(true);
       if (err) {
         return done(err);
       }
@@ -417,7 +417,7 @@ describe('S3rver Tests', function () {
       if (err) {
         return done(err);
       }
-      object.ETag.should.equal(md5('Hello!'));
+      object.ETag.should.equal('"' + md5('Hello!') + '"');
       object.ContentLength.should.equal('6');
       object.ContentType.should.equal('application/octet-stream');
       done();


### PR DESCRIPTION
The ETag should be surrounded by double quotes.

Some client libraries such as boto require this format and refuse GET requests otherwise:

`IOError: Cannot store S3 object "bucket/object": ETag from S3 did not match computed MD5. 34913be17f33fe36466f5b932aff626f vs. 34913be17f33fe36466f5b932aff626f`

RFC: https://tools.ietf.org/html/rfc7232#section-2.3

Amazon also lists quoted ETags in examples in their documentation:

https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html

There were quite a few occurrences in the code - hopefully I found all of them. The tests are passing and boto works as expected.
