### PR TITLE
Allow CORS Requests

### DIFF
--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -13,6 +13,7 @@ program.option('-h, --hostname [value]', 'Set the host name or ip for the server
   .option('-i, --indexDocumement', 'Index Document for Static Web Hosting', '')
   .option('-e, --errorDocument', 'Custom Error Document for Static Web Hosting', '')
   .option('-d, --directory [path]', 'Data directory')
+  .option('-c, --cors', 'Enable CORS', false)
   .parse(process.argv);
 
 if (program.directory === undefined) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -33,14 +33,16 @@ var app = function (options) {
       req.url = path.join('/', host, req.url);
     }
 
-    if (req.method === 'OPTIONS') {
-      if (req.headers['access-control-request-headers'])
-        res.header('Access-Control-Allow-Headers', req.headers['access-control-request-headers']);
-      if (req.headers['access-control-request-method'])
-        res.header('Access-Control-Allow-Methods', req.headers['access-control-request-method']);
+    if (options.cors) {
+      if (req.method === 'OPTIONS') {
+        if (req.headers['access-control-request-headers'])
+          res.header('Access-Control-Allow-Headers', req.headers['access-control-request-headers']);
+        if (req.headers['access-control-request-method'])
+          res.header('Access-Control-Allow-Methods', req.headers['access-control-request-method']);
+      }
+      if (req.headers.origin)
+        res.header('Access-Control-Allow-Origin', '*');
     }
-    if (req.headers.origin)
-      res.header('Access-Control-Allow-Origin', '*');
 
     next();
   });

--- a/lib/app.js
+++ b/lib/app.js
@@ -34,11 +34,13 @@ var app = function (options) {
     }
 
     if (req.method === 'OPTIONS') {
-      if (req.headers['access-control-request-method'])
-        res.header('Access-Control-Allow-Origin', '*');
       if (req.headers['access-control-request-headers'])
         res.header('Access-Control-Allow-Headers', req.headers['access-control-request-headers']);
+      if (req.headers['access-control-request-method'])
+        res.header('Access-Control-Allow-Methods', req.headers['access-control-request-method']);
     }
+    if (req.headers.origin)
+      res.header('Access-Control-Allow-Origin', '*');
 
     next();
   });

--- a/lib/app.js
+++ b/lib/app.js
@@ -33,6 +33,13 @@ var app = function (options) {
       req.url = path.join('/', host, req.url);
     }
 
+    if (req.method === 'OPTIONS') {
+      if (req.headers['access-control-request-method'])
+        res.header('Access-Control-Allow-Origin', '*');
+      if (req.headers['access-control-request-headers'])
+        res.header('Access-Control-Allow-Headers', req.headers['access-control-request-headers']);
+    }
+
     next();
   });
 


### PR DESCRIPTION
This is a simple solution to allow all CORS requests, which are necessary when using s3rver for testing web applications. I tested it with Chromium.