### PR TITLE
Allows users to plug in other file systems providers instead of fs-extra only 

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -4,7 +4,7 @@ var app = function (options) {
       app = express(),
       logger = require('./logger')(options.silent),
       Controllers = require('./controllers'),
-      controllers = new Controllers(options.directory, logger, options.indexDocument, options.errorDocument),
+      controllers = new Controllers(options.directory, logger, options.indexDocument, options.errorDocument,options.fs),
       concat = require('concat-stream'),
       path = require('path');
 

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -6,8 +6,8 @@ var FileStore = require('./file-store'),
     async = require('async'),
     path = require('path');
 
-module.exports = function (rootDirectory, logger, indexDocument, errorDocument) {
-  var fileStore = new FileStore(rootDirectory);
+module.exports = function (rootDirectory, logger, indexDocument, errorDocument,fs) {
+  var fileStore = new FileStore(rootDirectory,fs);
 
   var buildXmlResponse = function (res, status, template) {
     res.header('Content-Type', 'application/xml');

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -1,18 +1,20 @@
 'use strict';
 var path = require('path'),
-    fs = require('fs-extra'),
+   // fs = require('fs-extra'),
     async = require('async'),
     md5 = require('md5'),
     mkdirp = require('mkdirp'),
     utils = require('./utils'),
     _ = require('lodash');
 
-var FileStore = function (rootDirectory) {
+var FileStore = function (rootDirectory,fs) {
   var CONTENT_FILE = '.dummys3_content',
       METADATA_FILE = '.dummys3_metadata',
       Bucket = require('./models/bucket'),
       S3Object = require('./models/s3-object');
-
+  if (!fs){
+      fs = require('fs-extra');
+  }
   var getBucketPath = function (bucketName) {
     return path.join(rootDirectory, bucketName).replace(/\\/g, '/');
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var S3rver = function (options) {
     hostname: 'localhost',
     silent: false,
     indexDocument: '',
-    errorDocument: ''
+    errorDocument: '',
+    fs: require('fs-extra')
   };
 
   if (options) {
@@ -46,6 +47,13 @@ S3rver.prototype.setErrorDocument = function (errorDocument) {
   this.options.errorDocument = errorDocument;
   return this;
 };
+
+S3rver.prototype.setFs = function (fs) {
+  this.options.fs = fs;
+  return this;
+};
+
+
 
 S3rver.prototype.run = function (done) {
   var app = new App(this.options);


### PR DESCRIPTION
HI 
With these changes we can use any file system to be used as backend for s3rver .
Currently s3rver uses fs-extra as a file system for this server .  if a user has a file system which exposes functions with same semantics and signatures as that of fs file system but works under different environment or protocols  then we can use that in place of fs or fs extra 