### PR TITLE
Normalize x-amz-copy-source

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -263,6 +263,7 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument,f
       var template;
       var copy = req.headers['x-amz-copy-source'];
       if (copy) {
+        copy = copy.charAt(0) === '/' ? copy : '/' + copy
         var srcObjectParams = copy.split('/'),
             srcBucket = srcObjectParams[1],
             srcObject = srcObjectParams.slice(2).join('/');


### PR DESCRIPTION
Fixes https://github.com/jamhall/s3rver/issues/30

Since S3's documentation is ambiguous, `s3rver` should expect both versions of `x-amz-copy-source`. This change adds a '/' to `copy` in case `x-amz-copy-source` does not have a leading '/'.

For S3's documentation, see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html