### PR TITLE
Options not working

### DIFF
--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -10,8 +10,8 @@ program.version(version, '--version');
 program.option('-h, --hostname [value]', 'Set the host name or ip for the server', 'localhost')
   .option('-p, --port <n>', 'Set the port of the http server', 4568)
   .option('-s, --silent', 'Suppress log messages', false)
-  .option('-i, --indexDocumement', 'Index Document for Static Web Hosting', '')
-  .option('-e, --errorDocument', 'Custom Error Document for Static Web Hosting', '')
+  .option('-i, --indexDocument [path]', 'Index Document for Static Web Hosting', '')
+  .option('-e, --errorDocument [path]', 'Custom Error Document for Static Web Hosting', '')
   .option('-d, --directory [path]', 'Data directory')
   .option('-c, --cors', 'Enable CORS', false)
   .parse(process.argv);


### PR DESCRIPTION
Two things: the index document option was misspelt, and both that option and the error document one were returning booleans rather than paths, despite the requirements of controllers.js. I've changed both, and everything seems to be working as it should be.