### PR TITLE
Support setting the ContentDisposition parameter, other general improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ s3rver --help
 ## Supported clients
 
 Please see [Fake S3s wiki page](https://github.com/jubos/fake-s3/wiki/Supported-Clients) for a list of supported clients.
+When listening on HTTPS with a self-signed certificate, the AWS SDK in a Node.js environment will need ```httpOptions: { agent: new https.Agent({ rejectUnauthorized: false }) }``` in order to allow interaction.
 
 Please test, if you encounter any problems please do not hesitate to open an issue :)
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -4,9 +4,10 @@ var app = function (options) {
       app = express(),
       logger = require('./logger')(options.silent),
       Controllers = require('./controllers'),
-      controllers = new Controllers(options.directory, logger, options.indexDocument, options.errorDocument,options.fs),
+      controllers = new Controllers(options.directory, logger, options.indexDocument, options.errorDocument, options.fs),
       concat = require('concat-stream'),
-      path = require('path');
+      path = require('path'),
+      https = require('https');
 
   /**
    * Log all requests
@@ -64,7 +65,8 @@ var app = function (options) {
 
   return {
     serve: function (done) {
-      return app.listen(options.port, options.hostname, function (err) {
+      var server = ((options.key && options.cert) || options.pfx) ? https.createServer(options, app) : app;
+      return server.listen(options.port, options.hostname, function (err) {
         return done(err, options.hostname, options.port, options.directory);
       }).on('error', function (err) {
         return done(err);

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,5 +1,6 @@
 'use strict';
-var app = function (options) {
+
+module.exports = function (options) {
   var express = require('express'),
       app = express(),
       logger = require('./logger')(options.silent),
@@ -63,16 +64,14 @@ var app = function (options) {
   app.delete('/:bucket/:key(*)', controllers.bucketExists, controllers.deleteObject);
   app.post('/:bucket', controllers.bucketExists, controllers.genericPost);
 
-  return {
-    serve: function (done) {
-      var server = ((options.key && options.cert) || options.pfx) ? https.createServer(options, app) : app;
-      return server.listen(options.port, options.hostname, function (err) {
-        return done(err, options.hostname, options.port, options.directory);
-      }).on('error', function (err) {
-        return done(err);
-      });
-    }
+  app.serve = function (done) {
+    var server = ((options.key && options.cert) || options.pfx) ? https.createServer(options, app) : app;
+    return server.listen(options.port, options.hostname, function (err) {
+      return done(err, options.hostname, options.port, options.directory);
+    }).on('error', function (err) {
+      return done(err);
+    });
   };
-};
 
-module.exports = app;
+  return app;
+};

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -6,8 +6,8 @@ var FileStore = require('./file-store'),
     async = require('async'),
     path = require('path');
 
-module.exports = function (rootDirectory, logger, indexDocument, errorDocument,fs) {
-  var fileStore = new FileStore(rootDirectory,fs);
+module.exports = function (rootDirectory, logger, indexDocument, errorDocument, fs) {
+  var fileStore = new FileStore(rootDirectory, fs);
 
   var buildXmlResponse = function (res, status, template) {
     res.header('Content-Type', 'application/xml');
@@ -23,6 +23,9 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument,f
 
     if (object.contentEncoding)
       res.header('Content-Encoding', object.contentEncoding);
+    
+    if (object.contentDisposition)
+      res.header('Content-Disposition', object.contentDisposition);
 
     res.header('Content-Length', object.size);
     if (object.customMetaData.length > 0) {

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -186,6 +186,7 @@ var FileStore = function (rootDirectory,fs) {
       md5: json.md5,
       contentType: json.contentType,
       contentEncoding: json.contentEncoding,
+      contentDisposition: json.contentDisposition,
       size: json.size,
       modifiedDate: json.modifiedDate,
       creationDate: json.creationDate,
@@ -212,6 +213,7 @@ var FileStore = function (rootDirectory,fs) {
     var contentFile = data.contentFile,
         type = data.type,
         encoding = data.encoding,
+        disposition = data.disposition,
         metaFile = data.metaFile,
         headers = data.headers;
     async.parallel([
@@ -245,6 +247,8 @@ var FileStore = function (rootDirectory,fs) {
       };
       if (encoding)
         metaData.contentEncoding = encoding;
+      if (disposition)
+        metaData.contentDisposition = disposition;
 
       fs.writeFile(metaFile, JSON.stringify(metaData), function (err) {
         if (err) {
@@ -271,6 +275,7 @@ var FileStore = function (rootDirectory,fs) {
         contentFile: contentFile,
         type: req.headers['content-type'],
         encoding: req.headers['content-encoding'],
+        disposition: req.headers['content-disposition'],
         key: key,
         metaFile: metaFile,
         headers: req.headers

--- a/lib/models/s3-object.js
+++ b/lib/models/s3-object.js
@@ -4,6 +4,7 @@ var S3Object = function (s3Item) {
     key: s3Item.key,
     contentType: s3Item.contentType,
     contentEncoding: s3Item.contentEncoding,
+    contentDisposition: s3Item.contentDisposition,
     md5: s3Item.md5,
     size: s3Item.size,
     modifiedDate: s3Item.modifiedDate,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 exports.walk = function (dir) {
   var fs = require('fs');
   var path = require('path');
+  var url = require('url');
   var results = [];
   var list = fs.readdirSync(dir);
 
@@ -10,7 +11,7 @@ exports.walk = function (dir) {
     file = path.join(dir, file);
     var stat = fs.statSync(file);
     if (stat && stat.isDirectory()) {
-      results.push(file);
+      results.push(url.resolve(file, ''));
       results = results.concat(exports.walk(file));
     }
   });


### PR DESCRIPTION
Sorry these commits are a bit all over the place, there were just a few features I needed immediately and didn't organize them into separate branches for separate pull requests. Let me though if this is problematic.

I'll just outline in a bit more detail exactly what these do:

1. Instead of returning an `app` object with just the custom serve method, I extended the express app with the serve method and returned the express app. This allows s3rver to run on the same port as an existing web server when using express's app mounting feature.
2. There was a bug that prevented using prefix matching and possibly some other path-related functions on Windows since the `fs` module adapts to the OS when creating path strings. I just used `url.format()` to essentially replace `\\` with `/` in the paths, functionality now appears to be restored.
3. When you pass the necessary fields in the options object for s3rver, `app.serve()` will now attempt to listen on HTTPS. I put a note in the readme for setting up the AWS SDK to work with s3rver running in HTTPS mode.
4. Store and set the ContentDisposition header if provided. The main use of this is for setting the filename of a download and whether it should be downloaded or attempted to be displayed inline. I've tested code utilizing this header on s3rver and on the real thing, this part definitely works.

I've been actively using my fork and I think these changes are worthy of being merged back in, again let me know if there's anything I need to adjust here.