### PR TITLE
Files likely not closed after writing

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -297,6 +297,7 @@ var FileStore = function (rootDirectory,fs) {
       return done('Error writing file');
     });
     writeStream.on('finish', function () {
+      writeStream.end();
       createMetaData({
         contentFile: contentFile,
         type: req.headers['content-type'],


### PR DESCRIPTION
This was probably introduced in eeb5793 after I changed `fs` calls to use streams. On Windows, Node.js still has a filesystem lock on new files and attempting to delete (and likely overwrite) them will result in
```
EPERM: operation not permitted, stat 'c:\...'
```
until the offending process is restarted.

I think I know where to look to fix it, I should have time tomorrow to attach a pull request if this isn't resolved by then.