### PR TITLE
Support domain-style bucket names.

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -25,7 +25,7 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
 
     if (object.contentEncoding)
       res.header('Content-Encoding', object.contentEncoding);
-    
+
     if (object.contentDisposition)
       res.header('Content-Disposition', object.contentDisposition);
 
@@ -191,7 +191,7 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
       /**
        * Derived from http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
        */
-      if ((/^[a-z0-9]+(-[a-z0-9]+)*$/.test(bucketName) === false)) {
+      if ((/^[a-z0-9]+(.?[-a-z0-9]+)*$/.test(bucketName) === false)) {
         template = templateBuilder.buildError('InvalidBucketName',
             'Bucket names can contain lowercase letters, numbers, and hyphens. ' +
             'Each label must start and end with a lowercase letter or a number.');

--- a/test/test.js
+++ b/test/test.js
@@ -78,8 +78,24 @@ describe('S3rver Tests', function () {
     });
   });
 
+  it('should create a bucket with valid domain-style name', function (done) {
+    s3Client.createBucket({Bucket: 'a-test.example.com'}, function (err) {
+      should.not.exist(err);
+      done();
+    });
+  });
+
   it('should fail to create a bucket because of invalid name', function (done) {
     s3Client.createBucket({Bucket: '-$%!nvalid'}, function (err) {
+      err.statusCode.should.equal(400);
+      err.code.should.equal('InvalidBucketName');
+      should.exist(err);
+      done();
+    });
+  });
+
+  it('should fail to create a bucket because of invalid domain-style name', function (done) {
+    s3Client.createBucket({Bucket: '.example.com'}, function (err) {
       err.statusCode.should.equal(400);
       err.code.should.equal('InvalidBucketName');
       should.exist(err);


### PR DESCRIPTION
The regex was wrong. In order to support domain-style buckets with
subdomains, `.` must be allowed. This now better matches the S3 docs.