### PR TITLE
Add Log Label

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,7 +8,8 @@ module.exports = function (silent) {
         level: 'debug',
         handleExceptions: true,
         json: false,
-        colorize: true
+        colorize: true,
+        label: 'S3rver'
       })
     ],
     exitOnError: false


### PR DESCRIPTION
Add a log label to create a clear delineation between S3rver logs and an users application.  This is particularly useful when using S3rver programmatically within an application (e.g. during development or testing time).