### PR TITLE
Respond to requests on bucket vhost

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -23,7 +23,11 @@ module.exports = function (options) {
   app.use(function (req, res, next) {
     var host = req.headers.host.split(':')[0];
 
-    if (options.indexDocument && host !== 'localhost' && host !== '127.0.0.1') {
+    // Handle requests for <bucket>.s3(-<region>?).amazonaws.com, if they arrive.
+    var bucket = (/(.+)\.s3(-.+)?\.amazonaws\.com$/.exec(host) || [])[1];
+    if (bucket) {
+      req.url = path.join('/', bucket, req.url);
+    } else if (options.indexDocument && host !== 'localhost' && host !== '127.0.0.1') {
       req.url = path.join('/', host, req.url);
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -712,6 +712,24 @@ describe('S3rver Tests', function () {
       done();
     });
   });
+
+  it('should reach the server with a bucket vhost', function (done) {
+    request({ url: 'http://localhost:4569/', headers: { host: buckets[0] + '.s3.amazonaws.com' } }, function (err, response, body) {
+      if (err) {
+        return done(err);
+      }
+
+      if (response.statusCode !== 200) {
+        return done(new Error('Invalid status: ' + response.statusCode));
+      }
+
+      if (body.indexOf('ListBucketResult') === -1) {
+        return done(new Error('Unexpected response: ' + body));
+      }
+
+      done();
+    });
+  });
 });
 
 describe('S3rver Tests with Static Web Hosting', function () {


### PR DESCRIPTION
I have a situation where I'm testing S3 interaction code as a black box. I can't (or prefer not to) modify the code to point to a special S3 endpoint and force path-style requests. Instead, what I'd like to do is intercept traffic bound for `[bucket].s3.amazonaws.com` and redirect that traffic to s3rver, e.g. with a rule in /etc/hosts.

This PR has s3rver parse the `host` header and, if it matches a [bucket vhost](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro), then it handles the request for that bucket.

This only changes the behavior when s3rver receives a request with a host like `[bucket].s3(-[region])?.amazonaws.com`, so normal usage stays the same.
