### PR TITLE
Expose TLS options through CLI

### DIFF
--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -14,6 +14,8 @@ program.option('-h, --hostname [value]', 'Set the host name or ip for the server
   .option('-e, --errorDocument [path]', 'Custom Error Document for Static Web Hosting', '')
   .option('-d, --directory [path]', 'Data directory')
   .option('-c, --cors', 'Enable CORS', false)
+  .option('--key [path]', 'Path to private key file for running with TLS')
+  .option('--cert [path]', 'Path to certificate file for running with TLS')
   .parse(process.argv);
 
 if (program.directory === undefined) {
@@ -30,6 +32,11 @@ try {
 catch (e) {
   console.error('Directory does not exist. Please create it and then run the command again');
   process.exit();
+}
+
+if (program.key && program.cert) {
+  program.key = fs.readFileSync(program.key);
+  program.cert = fs.readFileSync(program.cert);
 }
 
 var s3rver = new S3rver(program).run(function (err, host, port) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,13 @@ var S3rver = function (options) {
 
   if (options) {
     this.options = _.merge(this.options, options);
+
+    // Lodash 3 does not merge Buffers correctly.
+    // https://github.com/lodash/lodash/issues/1453
+    if (options.key && options.cert) {
+      this.options.key = options.key;
+      this.options.cert = options.cert;
+    }
   }
 
 };

--- a/test/test.js
+++ b/test/test.js
@@ -849,7 +849,9 @@ describe('S3rver Class Tests', function() {
       hostname: 'testhost',
       indexDocument: 'index.html',
       errorDocument: '',
-      directory: '/tmp/s3rver_test_directory'
+      directory: '/tmp/s3rver_test_directory',
+      key: new Buffer([1, 2, 3]),
+      cert: new Buffer([1, 2, 3])
     })
 
     s3rver.options.should.have.property('hostname', 'testhost')
@@ -859,6 +861,10 @@ describe('S3rver Class Tests', function() {
     s3rver.options.should.have.property('errorDocument', '')
     s3rver.options.should.have.property('directory', '/tmp/s3rver_test_directory')
     s3rver.options.should.have.property('fs')
+    s3rver.options.should.have.property('key')
+    s3rver.options.should.have.property('cert')
+    s3rver.options.key.should.be.an.instanceOf(Buffer)
+    s3rver.options.cert.should.be.an.instanceOf(Buffer)
   })
 
 });


### PR DESCRIPTION
The `S3rver` class already accepts `key` and `cert` options for running with TLS. This PR exposes those options through the CLI.

Running with TLS is useful in conjunction with #49: we can supply a self-signed certificate for *.amazonaws.com, and then have s3rver handle requests intended for https://[bucket].s3.amazonaws.com, the default endpoint used by AWS SDKs.
