### PR TITLE
Add support for copying objects with metadata replace

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -296,12 +296,14 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
               return buildXmlResponse(res, 404, template);
             }
 
+            var replaceMetadata = req.headers['x-amz-metadata-directive'] === 'REPLACE';
             fileStore.copyObject({
               request: req,
               srcKey: srcObject,
               srcBucket: bucket,
               destBucket: req.bucket,
-              destKey: req.params.key
+              destKey: req.params.key,
+              replaceMetadata: replaceMetadata
 
             }, function (err, key) {
               if (err) {

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -332,11 +332,14 @@ var FileStore = function (rootDirectory,fs) {
     }
 
     if (replaceMetadata) {
+      var originalObject =
+            buildS3ObjectFromMetaDataFile(srcKey,
+                                          fs.readFileSync(srcMetadataFilePath));
       createMetaData({
         contentFile: destContentFilePath,
-        type: req.headers['content-type'],
-        encoding: req.headers['content-encoding'],
-        disposition: req.headers['content-disposition'],
+        type: originalObject.contentType,
+        encoding: originalObject.contentEncoding,
+        disposition: originalObject.contentDisposition,
         key: srcKey,
         metaFile: destMetadataFilePath,
         headers: req.headers

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -318,6 +318,7 @@ var FileStore = function (rootDirectory,fs) {
         srcKey = options.srcKey,
         destKey = options.destKey,
         destBucket = options.destBucket,
+        replaceMetadata = options.replaceMetadata || (srcKeyPath === destKeyPath),
         srcKeyPath = path.resolve(getBucketPath(srcBucket.name), srcKey),
         destKeyPath = path.resolve(getBucketPath(destBucket.name), destKey),
         srcMetadataFilePath = path.join(srcKeyPath, METADATA_FILE),
@@ -325,14 +326,19 @@ var FileStore = function (rootDirectory,fs) {
         destMetadataFilePath = path.join(destKeyPath, METADATA_FILE),
         destContentFilePath = path.join(destKeyPath, CONTENT_FILE);
 
-    if (srcKeyPath == destKeyPath) {
+    if (srcKeyPath !== destKeyPath) {
+      fs.mkdirpSync(destKeyPath);
+      fs.copySync(srcContentFilePath, destContentFilePath);
+    }
+
+    if (replaceMetadata) {
       createMetaData({
-        contentFile: srcContentFilePath,
+        contentFile: destContentFilePath,
         type: req.headers['content-type'],
         encoding: req.headers['content-encoding'],
         disposition: req.headers['content-disposition'],
         key: srcKey,
-        metaFile: srcMetadataFilePath,
+        metaFile: destMetadataFilePath,
         headers: req.headers
       }, function (err, metaData) {
         if (err) {
@@ -341,10 +347,7 @@ var FileStore = function (rootDirectory,fs) {
         return done(null, new S3Object(metaData));
       });
     } else {
-      fs.mkdirpSync(destKeyPath);
       fs.copySync(srcMetadataFilePath, destMetadataFilePath);
-      fs.copySync(srcContentFilePath, destContentFilePath);
-
       fs.readFile(destMetadataFilePath, function (err, data) {
         if (err) {
           return done(err);

--- a/lib/xml-template-builder.js
+++ b/lib/xml-template-builder.js
@@ -164,7 +164,7 @@ var xml = function () {
     buildCopyObject: function (item) {
       return jstoxml.toXML({
         CopyObjectResult: {
-          LastModified: item.modifiedDate,
+          LastModified: item.modifiedDate.toISOString(),
           ETag: '"' + item.md5 + '"'
         }
       }, {

--- a/test/test.js
+++ b/test/test.js
@@ -246,6 +246,7 @@ describe('S3rver Tests', function () {
         return done(err);
       }
       /"[a-fA-F0-9]{32}"/.test(data.ETag).should.equal(true);
+      moment(data.LastModified).isValid().should.equal(true);
       done();
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -251,15 +251,27 @@ describe('S3rver Tests', function () {
   });
 
   it('should update the metadata of an image object', function (done) {
+    var key = 'image/jamie';
     var params = {
       Bucket: buckets[3],
-      Key: 'image/jamie',
-      CopySource: '/' + buckets[3] + '/image/jamie',
+      Key: key,
+      CopySource: '/' + buckets[3] + '/' +  key,
       Metadata: {
         someKey: 'value'
       }
     };
-    s3Client.copyObject(params, done);
+    s3Client.copyObject(params, function (err, data) {
+      if (err) {
+        return done(err);
+      }
+      s3Client.getObject({Bucket: buckets[3], Key: key}, function (err, object) {
+        if (err) {
+          return done(err);
+        }
+        object.Metadata.somekey.should.equal('value');
+        done();
+      });
+    });
   });
 
   it('should fail to copy an image object because the object does not exist', function (done) {

--- a/test/test.js
+++ b/test/test.js
@@ -269,6 +269,7 @@ describe('S3rver Tests', function () {
           return done(err);
         }
         object.Metadata.somekey.should.equal('value');
+        object.ContentType.should.equal('image/jpeg');
         done();
       });
     });
@@ -294,6 +295,7 @@ describe('S3rver Tests', function () {
           return done(err);
         }
         object.Metadata.somekey.should.equal('value');
+        object.ContentType.should.equal('image/jpeg');
         done();
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -274,6 +274,31 @@ describe('S3rver Tests', function () {
     });
   });
 
+  it('should copy an image object into another bucket and update its metadata', function (done) {
+    var key = 'image/jamie';
+    var params = {
+      Bucket: buckets[3],
+      Key: key,
+      CopySource: '/' + buckets[0] + '/image',
+      MetadataDirective: 'REPLACE',
+      Metadata: {
+        someKey: 'value'
+      }
+    };
+    s3Client.copyObject(params, function (err, data) {
+      if (err) {
+        return done(err);
+      }
+      s3Client.getObject({Bucket: buckets[3], Key: key}, function (err, object) {
+        if (err) {
+          return done(err);
+        }
+        object.Metadata.somekey.should.equal('value');
+        done();
+      });
+    });
+  });
+
   it('should fail to copy an image object because the object does not exist', function (done) {
     var params = {
       Bucket: buckets[3],


### PR DESCRIPTION
Hi, thanks a lot for S3rver!

Our S3-based application uses object copying with metadata replacement, and we realized that it's not supported by S3rver. I just added the missing support. The relevant S3 operation is [PUT Object - Copy](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html), in particular, the `x-amz-metadata-directive` header.