### PR TITLE
Expose the Express app on S3rver instances

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -6,8 +6,7 @@ module.exports = function (options) {
       logger = require('./logger')(options.silent),
       Controllers = require('./controllers'),
       controllers = new Controllers(options.directory, logger, options.indexDocument, options.errorDocument, options.fs),
-      path = require('path'),
-      https = require('https');
+      path = require('path');
 
   /**
    * Log all requests
@@ -55,15 +54,6 @@ module.exports = function (options) {
   app.head('/:bucket/:key(*)', controllers.getObject);
   app.delete('/:bucket/:key(*)', controllers.bucketExists, controllers.deleteObject);
   app.post('/:bucket', controllers.bucketExists, controllers.genericPost);
-
-  app.serve = function (done) {
-    var server = ((options.key && options.cert) || options.pfx) ? https.createServer(options, app) : app;
-    return server.listen(options.port, options.hostname, function (err) {
-      return done(err, options.hostname, options.port, options.directory);
-    }).on('error', function (err) {
-      return done(err);
-    });
-  };
 
   return app;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,64 +1,39 @@
 'use strict';
 var App = require('./app');
 var _ = require('lodash');
+var https = require('https');
 
-var S3rver = function (options) {
-  this.options = {
-    port: 4578,
-    hostname: 'localhost',
-    silent: false,
-    indexDocument: '',
-    errorDocument: '',
-    fs: require('fs-extra')
-  };
+var defaultOptions = {
+  port: 4578,
+  hostname: 'localhost',
+  directory: '.',
+  silent: false,
+  indexDocument: '',
+  errorDocument: '',
+  fs: require('fs-extra')
+};
 
-  if (options) {
-    this.options = _.merge(this.options, options);
+function S3rver(options) {
+  this.options = _.merge({}, defaultOptions, options);
+  this.app = new App(this.options);
+}
+
+for (var option in defaultOptions) {
+  S3rver.prototype['set' + option.charAt(0).toUpperCase() + option.slice(1)] = function (value) {
+    this.options[option] = value;
+    this.app = new App(this.options);
+    return this;
   }
-
-};
-
-S3rver.prototype.setPort = function (port) {
-  this.options.port = port;
-  return this;
-};
-
-S3rver.prototype.setHostname = function (hostname) {
-  this.options.hostname = hostname;
-  return this;
-};
-
-S3rver.prototype.setDirectory = function (directory) {
-  this.options.directory = directory;
-  return this;
-};
-
-S3rver.prototype.setSilent = function (silent) {
-  this.options.silent = silent;
-  return this;
-};
-
-S3rver.prototype.setIndexDocument = function (indexDocument) {
-  this.options.indexDocument = indexDocument;
-  return this;
-};
-
-S3rver.prototype.setErrorDocument = function (errorDocument) {
-  this.options.errorDocument = errorDocument;
-  return this;
-};
-
-S3rver.prototype.setFs = function (fs) {
-  this.options.fs = fs;
-  return this;
-};
-
-
+}
 
 S3rver.prototype.run = function (done) {
-  var app = new App(this.options);
-  return app.serve(done);
-
+  var options = this.options;
+  var server = ((options.key && options.cert) || options.pfx)
+      ? https.createServer(options, this.app)
+      : this.app;
+  return server.listen(options.port, options.hostname, function (err) {
+    return done(err, options.hostname, options.port, options.directory);
+  }).on('error', done);
 };
 
 module.exports = S3rver;


### PR DESCRIPTION
The fs option added in #54 wasn't documented and was a breaking change, so I was pretty confused what was wrong for a bit. Using `fs-extra` by default makes it non breaking : ).