### PR TITLE
return Last-modified and Etag headers with 304 repsonse

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -19,8 +19,6 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
 
   var buildResponse = function (req, res, status, object, data) {
     res.header('Access-Control-Allow-Origin', '*');
-    res.header('Etag', '"' + object.md5 + '"');
-    res.header('Last-Modified', new Date(object.modifiedDate).toUTCString());
     res.header('Content-Type', object.contentType);
 
     if (object.contentEncoding)
@@ -258,6 +256,9 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
             return errorResponse(req, res, keyName);
           }
         }
+
+        res.header('Etag', '"' + object.md5 + '"');
+        res.header('Last-Modified', new Date(object.modifiedDate).toUTCString());
 
         var noneMatch = req.headers['if-none-match'];
         if (noneMatch && (noneMatch === '"' + object.md5 + '"' || noneMatch === '*')) {


### PR DESCRIPTION
Hello! 
In its current state, the server does not return cache headers when returning a 304 response. I've submitted this PR for your review to resolve this issue. 

The current behavior is causing some of my tests to fail in a project I'm working on because my code relies on the production AWS behavior which is to return these headers with the 304 response.

It's a pretty simple change, but please let me know if I can adjust the code in any way to better accommodate the project's preferred style. Thanks!