### PR TITLE
Do not fail when deleting a nonexistent object

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -97,36 +97,27 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
         return o.Key[0];
       });
       async.each(keys, function (key, cb) {
-          fileStore.getObjectExists(req.bucket, key, function (err) {
+        fileStore.getObjectExists(req.bucket, key, function (err) {
+          if (err) {
+            return cb();
+          }
+          fileStore.deleteObject(req.bucket, key, function (err) {
             if (err) {
-              var template = templateBuilder.buildKeyNotFound(key);
+              logger.error('Could not delete object "%s"', key, err);
+              var template = templateBuilder.buildError('InternalError',
+                'We encountered an internal error. Please try again.');
               cb(err);
-              return buildXmlResponse(res, 404, template);
+              return buildXmlResponse(res, 500, template);
             }
+            logger.info('Deleted object "%s" in bucket "%s"', key, req.bucket.name);
             cb();
           });
-        },
-        function done(err) {
-          if (err) return;
-          async.each(keys, function (key, cb) {
-              fileStore.deleteObject(req.bucket, key, function (err) {
-                if (err) {
-                  logger.error('Could not delete object "%s"', key, err);
-                  var template = templateBuilder.buildError('InternalError',
-                    'We encountered an internal error. Please try again.');
-                  cb(err);
-                  return buildXmlResponse(res, 500, template);
-                }
-                logger.info('Deleted object "%s" in bucket "%s"', key, req.bucket.name);
-                cb();
-              });
-            },
-            function done(err) {
-              if (err) return;
-              var template = templateBuilder.buildObjectsDeleted(keys);
-              return buildXmlResponse(res, 200, template);
-            });
         });
+      }, function (err) {
+        if (err) return;
+        var template = templateBuilder.buildObjectsDeleted(keys);
+        return buildXmlResponse(res, 200, template);
+      });
     });
   };
 
@@ -341,8 +332,7 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
       var key = req.params.key;
       fileStore.getObjectExists(req.bucket, key, function (err) {
         if (err) {
-          var template = templateBuilder.buildKeyNotFound(key);
-          return buildXmlResponse(res, 404, template);
+          return res.status(204).end();
         }
         fileStore.deleteObject(req.bucket, key, function (err) {
           if (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -456,6 +456,10 @@ describe('S3rver Tests', function () {
     });
   });
 
+  it('should not fail to delete a nonexistent object from a bucket', function (done) {
+    s3Client.deleteObject({Bucket: buckets[0], Key: 'doesnotexist'}, done);
+  });
+
   it('should fail to delete a bucket because it is not empty', function (done) {
     s3Client.deleteBucket({Bucket: buckets[0]}, function (err) {
       err.code.should.equal('BucketNotEmpty');
@@ -670,6 +674,19 @@ describe('S3rver Tests', function () {
       should.exist(resp.Deleted);
       should(resp.Deleted).have.length(500);
       should(resp.Deleted).containEql({Key: 'key567'});
+      done();
+    });
+  });
+
+  it('should return nonexistent objects as deleted with deleteObjects', function (done) {
+    var deleteObj = {Objects: [{Key: 'doesnotexist'}]};
+    s3Client.deleteObjects({Bucket: buckets[2], Delete: deleteObj}, function (err, resp) {
+      if (err) {
+        return done(err);
+      }
+      should.exist(resp.Deleted);
+      should(resp.Deleted).have.length(1);
+      should(resp.Deleted).containEql({Key: 'doesnotexist'});
       done();
     });
   });


### PR DESCRIPTION
If the object specified in the request is not found, `s3rver` responds with 404 error, unlike Amazon S3 that returns the result as deleted for both [single](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html) and [multi-object](http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html) operations.

Align `deleteObject` and `deleteObjects` with the API spec and return a success response even when the target object does not exist.