### PR TITLE
Add support for multipart uploads

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -51,6 +51,7 @@ module.exports = function (options) {
   app.delete('/:bucket', controllers.bucketExists, controllers.deleteBucket);
   app.put('/:bucket', controllers.putBucket);
   app.put('/:bucket/:key(*)', controllers.bucketExists, controllers.putObject);
+  app.post('/:bucket/:key(*)', controllers.bucketExists, controllers.postObject);
   app.get('/:bucket/:key(*)', controllers.bucketExists, controllers.getObject);
   app.head('/:bucket/:key(*)', controllers.getObject);
   app.delete('/:bucket/:key(*)', controllers.bucketExists, controllers.deleteObject);

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -6,7 +6,9 @@ var FileStore = require('./file-store'),
     xml2js = require('xml2js'),
     async = require('async'),
     path = require('path'),
-    ReadableStream = require('stream').Readable;
+    ReadableStream = require('stream').Readable,
+    crypto = require('crypto'),
+    url = require('url');
 
 module.exports = function (rootDirectory, logger, indexDocument, errorDocument, fs) {
   var fileStore = new FileStore(rootDirectory, fs);
@@ -119,6 +121,73 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
         return buildXmlResponse(res, 200, template);
       });
     });
+  };
+
+  var handleCopyObject = function (key, req, res) {
+    var template;
+    var copy = req.headers['x-amz-copy-source'];
+    copy = copy.charAt(0) === '/' ? copy : '/' + copy;
+    var srcObjectParams = copy.split('/'),
+        srcBucket = srcObjectParams[1],
+        srcObject = srcObjectParams.slice(2).join('/');
+    fileStore.getBucket(srcBucket, function (err, bucket) {
+      if (err) {
+        logger.error('No bucket found for "%s"', srcBucket);
+        template = templateBuilder.buildBucketNotFound(srcBucket);
+        return buildXmlResponse(res, 404, template);
+      }
+      fileStore.getObject(bucket, srcObject, function (err) {
+        if (err) {
+          logger.error('Object "%s" in bucket "%s" does not exist', srcObject, bucket.name);
+          template = templateBuilder.buildKeyNotFound(srcObject);
+          return buildXmlResponse(res, 404, template);
+        }
+
+        var replaceMetadata = req.headers['x-amz-metadata-directive'] === 'REPLACE';
+        fileStore.copyObject({
+          request: req,
+          srcKey: srcObject,
+          srcBucket: bucket,
+          destBucket: req.bucket,
+          destKey: key,
+          replaceMetadata: replaceMetadata
+
+        }, function (err, object) {
+          if (err) {
+            logger.error('Error copying object "%s" from bucket "%s" into bucket "%s" with key of "%s"',
+              srcObject, bucket.name, req.bucket.name, key);
+            template = templateBuilder.buildError('InternalError',
+              'We encountered an internal error. Please try again.');
+            return buildXmlResponse(res, 500, template);
+          }
+
+          logger.info('Copied object "%s" from bucket "%s"  into bucket "%s" with key of "%s"',
+            srcObject, bucket.name, req.bucket.name, key);
+          template = templateBuilder.buildCopyObject(object);
+          return buildXmlResponse(res, 200, template);
+        });
+      });
+    });
+  };
+
+  var putObjectMultipart = function (req, res) {
+    var partKey = req.query.uploadId + '_' + req.query.partNumber;
+    if (req.headers['x-amz-copy-source']) {
+      handleCopyObject(partKey, req, res);
+    } else {
+      fileStore.putObject(req.bucket, partKey, req, function (err, key) {
+        if (err) {
+          logger.error('Error uploading object "%s" to bucket "%s"',
+            partKey, req.bucket.name, err);
+          var template = templateBuilder.buildError('InternalError',
+            'We encountered an internal error. Please try again.');
+          return buildXmlResponse(res, 500, template);
+        }
+        logger.info('Stored object "%s" in bucket "%s" successfully', partKey, req.bucket.name);
+        res.header('ETag', '"' + key.md5 + '"');
+        return res.status(200).end();
+      });
+    }
   };
 
   /**
@@ -267,54 +336,14 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
       });
     },
     putObject: function (req, res) {
-      var template;
-      var copy = req.headers['x-amz-copy-source'];
-      if (copy) {
-        copy = copy.charAt(0) === '/' ? copy : '/' + copy
-        var srcObjectParams = copy.split('/'),
-            srcBucket = srcObjectParams[1],
-            srcObject = srcObjectParams.slice(2).join('/');
-        fileStore.getBucket(srcBucket, function (err, bucket) {
-          if (err) {
-            logger.error('No bucket found for "%s"', srcBucket);
-            template = templateBuilder.buildBucketNotFound(srcBucket);
-            return buildXmlResponse(res, 404, template);
-          }
-          fileStore.getObject(bucket, srcObject, function (err) {
-            if (err) {
-              logger.error('Object "%s" in bucket "%s" does not exist', srcObject, bucket.name);
-              template = templateBuilder.buildKeyNotFound(srcObject);
-              return buildXmlResponse(res, 404, template);
-            }
-
-            var replaceMetadata = req.headers['x-amz-metadata-directive'] === 'REPLACE';
-            fileStore.copyObject({
-              request: req,
-              srcKey: srcObject,
-              srcBucket: bucket,
-              destBucket: req.bucket,
-              destKey: req.params.key,
-              replaceMetadata: replaceMetadata
-
-            }, function (err, key) {
-              if (err) {
-                logger.error('Error copying object "%s" from bucket "%s" into bucket "%s" with key of "%s"',
-                  srcObject, bucket.name, req.bucket.name, req.params.key);
-                template = templateBuilder.buildError('InternalError',
-                  'We encountered an internal error. Please try again.');
-                return buildXmlResponse(res, 500, template);
-              }
-
-              logger.info('Copied object "%s" from bucket "%s"  into bucket "%s" with key of "%s"',
-                srcObject, bucket.name, req.bucket.name, req.params.key);
-              template = templateBuilder.buildCopyObject(key);
-              return buildXmlResponse(res, 200, template);
-            });
-          });
-        });
+      if (req.query.uploadId) {
+        return putObjectMultipart(req, res);
       }
-      else {
-        fileStore.putObject(req.bucket, req, function (err, key) {
+
+      if (req.headers['x-amz-copy-source']) {
+        handleCopyObject(req.params.key, req, res);
+      } else {
+        fileStore.putObject(req.bucket, req.params.key, req, function (err, key) {
           if (err) {
             logger.error('Error uploading object "%s" to bucket "%s"',
               req.params.key, req.bucket.name, err);
@@ -325,6 +354,51 @@ module.exports = function (rootDirectory, logger, indexDocument, errorDocument, 
           logger.info('Stored object "%s" in bucket "%s" successfully', req.params.key, req.bucket.name);
           res.header('ETag', '"' + key.md5 + '"');
           return res.status(200).end();
+        });
+      }
+    },
+    postObject: function (req, res) {
+      if (req.query.uploads !== undefined) {
+        var uploadId = crypto.randomBytes(16).toString('hex');
+        return buildXmlResponse(res, 200, templateBuilder.buildInitiateMultipartUploadResult(req.bucket.name, req.params.key, uploadId));
+      } else {
+        var completeMultipartUploadXml = '';
+
+        req.on('data', function (data) {
+          completeMultipartUploadXml += data.toString('utf8');
+        });
+
+        req.on('end', function () {
+          xml2js.parseString(completeMultipartUploadXml, function (err, result) {
+            if (err) {
+              logger.error('Error completing multipart upload "%s" for object "%s" in bucket "%s"',
+                req.query.uploadId, req.params.key, req.bucket.name, err);
+              var template = templateBuilder.buildError('XMLParseError', err.message);
+              return buildXmlResponse(res, 400, template);
+            }
+
+            var parts = result.CompleteMultipartUpload.Part.map(function (part) {
+              return {
+                number: part.PartNumber[0],
+                etag: part.ETag[0].replace('"', '')
+              };
+            });
+
+            fileStore.combineObjectParts(req.bucket, req.params.key, req.query.uploadId, parts, req, function (err, key) {
+              if (err) {
+                logger.error('Error uploading object "%s" to bucket "%s"',
+                  req.params.key, req.bucket.name, err);
+                var template = templateBuilder.buildError('InternalError',
+                  'We encountered an internal error. Please try again.');
+                return buildXmlResponse(res, 500, template);
+              }
+              logger.info('Stored object "%s" in bucket "%s" successfully', req.params.key, req.bucket.name);
+              var location = req.protocol + '://' + req.get('Host') + url.parse(req.originalUrl).pathname;
+              return buildXmlResponse(res, 200,
+                templateBuilder.buildCompleteMultipartUploadResult(req.bucket.name, req.params.key, location, key)
+              );
+            });
+          });
         });
       }
     },

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -2,6 +2,7 @@
 var path = require('path'),
     async = require('async'),
     crypto = require('crypto'),
+    PassThrough = require('stream').PassThrough,
     utils = require('./utils'),
     _ = require('lodash');
 
@@ -280,14 +281,12 @@ var FileStore = function (rootDirectory,fs) {
     });
   };
 
-  var putObject = function (bucket, req, done) {
-    var keyName = path.join(bucket.name, req.params.key);
+  var putObject = function (bucket, key, req, done) {
+    var keyName = path.join(bucket.name, key);
     var dirName = path.join(rootDirectory, keyName);
     fs.mkdirpSync(dirName);
     var contentFile = path.join(dirName, CONTENT_FILE);
     var metaFile = path.join(dirName, METADATA_FILE);
-    var key = req.params.key;
-    key = key.substr(key.lastIndexOf('/') + 1);
     var writeStream = req.pipe(fs.createWriteStream(contentFile));
     writeStream.on('error', function (err) {
       return done('Error writing file');
@@ -383,6 +382,53 @@ var FileStore = function (rootDirectory,fs) {
     });
   };
 
+  var concatStreams = function (passThrough, streams) {
+    var stream = streams.shift();
+    if (!stream) {
+      passThrough.end();
+      return passThrough;
+    }
+    stream.once('end', function () { concatStreams(passThrough, streams); });
+    stream.pipe(passThrough, { end: false });
+    return passThrough;
+  };
+
+  var combineObjectParts = function (bucket, key, uploadId, parts, req, done) {
+    var sortedParts = _.sortBy(parts, function (part) { return part.number; });
+    var partPaths = _.map(sortedParts, function (part) {
+      return path.resolve(getBucketPath(bucket.name), uploadId + '_' + part.number);
+    });
+    var partStreams = _.map(partPaths, function (partPath) { return fs.createReadStream(path.join(partPath, CONTENT_FILE)); });
+    var combinedPartsStream = concatStreams(new PassThrough(), partStreams);
+    var keyName = path.join(bucket.name, key);
+    var dirName = path.join(rootDirectory, keyName);
+    fs.mkdirpSync(dirName);
+    var contentFile = path.join(dirName, CONTENT_FILE);
+    var metaFile = path.join(dirName, METADATA_FILE);
+    var writeStream = combinedPartsStream.pipe(fs.createWriteStream(contentFile));
+    writeStream.on('error', function (err) {
+      return done(err);
+    });
+    writeStream.on('finish', function () {
+      writeStream.end();
+      _.forEach(partPaths, function (partPath) { fs.removeSync(partPath); });
+      createMetaData({
+        contentFile: contentFile,
+        type: req.headers['content-type'],
+        encoding: req.headers['content-encoding'],
+        disposition: req.headers['content-disposition'],
+        key: key,
+        metaFile: metaFile,
+        headers: req.headers
+      }, function (err, metaData) {
+        if (err) {
+          return done(err);
+        }
+        return done(null, new S3Object(metaData));
+      });
+    });
+  };
+
   return {
     getBuckets: getBuckets,
     getBucket: getBucket,
@@ -393,7 +439,8 @@ var FileStore = function (rootDirectory,fs) {
     putObject: putObject,
     copyObject: copyObject,
     getObjectExists: getObjectExists,
-    deleteObject: deleteObject
+    deleteObject: deleteObject,
+    combineObjectParts: combineObjectParts
   };
 };
 module.exports = FileStore;

--- a/lib/xml-template-builder.js
+++ b/lib/xml-template-builder.js
@@ -171,6 +171,31 @@ var xml = function () {
         header: true,
         indent: '  '
       });
+    },
+    buildInitiateMultipartUploadResult: function (bucket, key, uploadId) {
+      return jstoxml.toXML({
+        InitiateMultipartUploadResult: {
+          Bucket: bucket,
+          Key: key,
+          UploadId: uploadId
+        }
+      }, {
+        header: true,
+        indent: '  '
+      });
+    },
+    buildCompleteMultipartUploadResult: function (bucket, key, location, item) {
+      return jstoxml.toXML({
+        CompleteMultipartUploadResult: {
+          Location: location,
+          Bucket: bucket,
+          Key: key,
+          ETag: '"' + item.md5 + '"'
+        }
+      }, {
+        header: true,
+        indent: ' '
+      });
     }
   };
 };

--- a/test/test.js
+++ b/test/test.js
@@ -479,6 +479,28 @@ describe('S3rver Tests', function () {
     });
   });
 
+  it('should upload a managed upload <=5MB', function (done) {
+    var params = { Bucket: buckets[0], Key: 'multi/directory/path/multipart', Body: Buffer.alloc(5e+6) }; // 5MB
+    s3Client.upload(params, function (err, data) {
+      (/"[a-fA-F0-9]{32}"/).test(data.ETag).should.equal(true);
+      if (err) {
+        return done(err);
+      }
+      done();
+    });
+  });
+
+  it('should upload a managed upload >5MB (multipart upload)', function (done) {
+    var params = { Bucket: buckets[0], Key: 'multi/directory/path/multipart', Body: Buffer.alloc(2e+7) }; // 20MB
+    s3Client.upload(params, function (err, data) {
+      (/"[a-fA-F0-9]{32}"/).test(data.ETag).should.equal(true);
+      if (err) {
+        return done(err);
+      }
+      done();
+    });
+  });
+
   it('should find a text file in a multi directory path', function (done) {
     s3Client.getObject({Bucket: buckets[0], Key: 'multi/directory/path/text'}, function (err, object) {
       if (err) {


### PR DESCRIPTION
Resolves #33 

Multipart uploads is a major feature missing from this mock S3 server. Without it, it's impossible to test uploading files larger than 5MB using `aws-sdk`:

```javascript
const s3 = new AWS.S3()
// ...
s3.upload(params, (err, data) => {})
```