### PR TITLE
wait for writeStream file descriptor to close before calling fs.stat

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -293,7 +293,7 @@ var FileStore = function (rootDirectory) {
     writeStream.on('error', function (err) {
       return done('Error writing file');
     });
-    writeStream.on('finish', function () {
+    writeStream.on('close', function () {
       writeStream.end();
       createMetaData({
         contentFile: contentFile,
@@ -414,7 +414,7 @@ var FileStore = function (rootDirectory) {
     writeStream.on('error', function (err) {
       return done(err);
     });
-    writeStream.on('finish', function () {
+    writeStream.on('close', function () {
       writeStream.end();
       _.forEach(partPaths, function (partPath) { fs.removeSync(partPath); });
       createMetaData({


### PR DESCRIPTION
This resolves a subtle non-deterministic bug caused by attempting to access saved upload data in order to create metadata immediately after.

In my integration tests uploading thousands of files, I would sometimes get an `ENOENT` on the `fs.stat` call in `createMetaData` function in `lib/file-store.js`.

It appears we're listening on the generic `finish` stream event before calling `createMetaData`, where we really should be listening on the [`close` event](https://nodejs.org/api/fs.html#fs_event_close_1) which is emitted after the underlying file descriptor is closed (therefore guaranteeing the file exists when `fs.stat` is being called in `createMetaData`). It appears listening on the `finish` event does not provide this guarantee, while it will work most of the time.