### PR TITLE
Don't generate package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
With npm 5, I have to run `npm update --no-save` or delete my local `package-lock.json` to keep dependencies up to date without making changes that interfere with the renovate bot. `package-lock` only really makes sense for apps whereas we're only concerned about we put on npm.