### PR TITLE
Find only short common prefixes when using Delimiter and Prefix

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -120,7 +120,7 @@ const FileStore = function (rootDirectory) {
         const truncatedKey = key.replace(bucketPath + "/", "");
         if (truncatedKey.slice(0, options.prefix.length) == options.prefix) {
           if (truncatedKey.indexOf(options.delimiter, options.prefix.length + 1) > -1) {
-            const commonPrefix = truncatedKey.substring(0, truncatedKey.lastIndexOf(options.delimiter) + 1);
+            const commonPrefix = truncatedKey.substring(0, truncatedKey.indexOf(options.delimiter, options.prefix.length + 1) + 1);
             if (commonPrefixes.indexOf(commonPrefix) == -1) {
               commonPrefixes.push(commonPrefix);
               commonPrefixes.sort();

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ S3rver.defaultOptions.directory = tmpDir;
 
 /**
  * Remove if exists and recreate the temporary directory
- * 
+ *
  * Be aware of https://github.com/isaacs/rimraf/issues/25
  * Buckets can fail to delete on Windows likely due to a bug/shortcoming in Node.js
  */
@@ -157,7 +157,7 @@ describe('S3rver Tests', function () {
       s3Client.listObjects({Bucket: buckets[4]}, function (err) {
         err.code.should.equal('NoSuchBucket');
         err.statusCode.should.equal(404);
-        done();        
+        done();
       })
     })
   });
@@ -831,7 +831,7 @@ describe('S3rver Tests', function () {
   });
 
   it('should generate a few thousand small objects', function (done) {
-    this.timeout(0);    
+    this.timeout(0);
     const testObjects = [];
     for (let i = 1; i <= 2000; i++) {
       testObjects.push({Bucket: buckets[2], Key: 'key' + i, Body: 'Hello!'});
@@ -861,7 +861,7 @@ describe('S3rver Tests', function () {
   });
 
   it('should return 500 small objects', function (done) {
-    this.timeout(0);    
+    this.timeout(0);
     generateTestObjects(s3Client, buckets[2], 1000, function () {
       s3Client.listObjects({'Bucket': buckets[2], MaxKeys: 500}, function (err, objects) {
         if (err) {
@@ -874,7 +874,7 @@ describe('S3rver Tests', function () {
   });
 
   it('should delete 500 small objects', function (done) {
-    this.timeout(0);        
+    this.timeout(0);
     generateTestObjects(s3Client, buckets[2], 500, function () {
       const testObjects = [];
       for (let i = 1; i <= 500; i++) {
@@ -887,7 +887,7 @@ describe('S3rver Tests', function () {
   });
 
   it('should delete 500 small objects with deleteObjects', function (done) {
-    this.timeout(0);    
+    this.timeout(0);
     generateTestObjects(s3Client, buckets[2], 500, function () {
       const deleteObj = {Objects: []};
       for (let i = 501; i <= 1000; i++) {
@@ -1151,7 +1151,7 @@ describe('S3rver Tests with Static Web Hosting', function () {
       s3Client.putObject(params, function (err, data) {
         request(s3Client.endpoint.href + 'site/', function (error, response, body) {
           if (error) return done(error);
-    
+
           response.statusCode.should.equal(200);
           body.should.equal(expectedBody);
           done();

--- a/test/test.js
+++ b/test/test.js
@@ -798,11 +798,10 @@ describe('S3rver Tests', function () {
         if (err) {
           return done(err);
         }
-        should(objects.CommonPrefixes.length).equal(4);
+        should(objects.CommonPrefixes.length).equal(3);
         should.exist(_.find(objects.CommonPrefixes, {'Prefix': 'folder1/folder2/'}));
         should.exist(_.find(objects.CommonPrefixes, {'Prefix': 'folder1/folder3/'}));
         should.exist(_.find(objects.CommonPrefixes, {'Prefix': 'folder1/folder4/'}));
-        should.exist(_.find(objects.CommonPrefixes, {'Prefix': 'folder1/folder4/folder5/'}));
         done();
       });
     });


### PR DESCRIPTION
Previously, all common prefixes were returned when using both `Delimiter` and `Prefix`, but s3 only provides the shortest. For example, I created this hierarchy (taken from the tests) in S3:

```
const paths = [
  'folder1/file1.txt',
  'folder1/file2.txt',
  'folder1/folder2/file3.txt',
  'folder1/folder2/file4.txt',
  'folder1/folder2/file5.txt',
  'folder1/folder2/file6.txt',
  'folder1/folder4/file7.txt',
  'folder1/folder4/file8.txt',
  'folder1/folder4/folder5/file9.txt',
  'folder1/folder3/file10.tx',
];
```

When running `listObjects()` with `{Delimiter: '/', Prefix: 'folder1/'}`, I get:

```
{
  ...
  Contents: 
   [ { Key: 'folder1/file1.txt', ... },
     { Key: 'folder1/file2.txt', ... } ],
  Prefix: 'folder1/',
  Delimiter: '/',
  CommonPrefixes: 
   [ { Prefix: 'folder1/folder2/' },
     { Prefix: 'folder1/folder3/' },
     { Prefix: 'folder1/folder4/' } ]
}
```

This turns out to be slightly different from `s3rver`'s behavior, which also includes `folder1/folder4/folder5/` in the common prefixes.