### PR TITLE
Fix copyObject operations with "COPY" MetadataDirective

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -343,18 +343,18 @@ const FileStore = function(rootDirectory) {
   };
 
   const copyObject = function(options, done) {
-    var req = options.request,
-      srcBucket = options.srcBucket,
-      srcKey = options.srcKey,
-      destKey = options.destKey,
-      destBucket = options.destBucket,
-      replaceMetadata = options.replaceMetadata || srcKeyPath === destKeyPath,
-      srcKeyPath = path.resolve(getBucketPath(srcBucket.name), srcKey),
-      destKeyPath = path.resolve(getBucketPath(destBucket.name), destKey),
-      srcMetadataFilePath = path.join(srcKeyPath, METADATA_FILE),
-      srcContentFilePath = path.join(srcKeyPath, CONTENT_FILE),
-      destMetadataFilePath = path.join(destKeyPath, METADATA_FILE),
-      destContentFilePath = path.join(destKeyPath, CONTENT_FILE);
+    const req = options.request;
+    const srcBucket = options.srcBucket;
+    const srcKey = options.srcKey;
+    const destBucket = options.destBucket;
+    const destKey = options.destKey;
+    const srcKeyPath = path.resolve(getBucketPath(srcBucket.name), srcKey);
+    const destKeyPath = path.resolve(getBucketPath(destBucket.name), destKey);
+    const replaceMetadata = options.replaceMetadata;
+    const srcMetadataFilePath = path.join(srcKeyPath, METADATA_FILE);
+    const srcContentFilePath = path.join(srcKeyPath, CONTENT_FILE);
+    const destMetadataFilePath = path.join(destKeyPath, METADATA_FILE);
+    const destContentFilePath = path.join(destKeyPath, CONTENT_FILE);
 
     if (srcKeyPath !== destKeyPath) {
       fs.mkdirpSync(destKeyPath);

--- a/lib/xml-template-builder.js
+++ b/lib/xml-template-builder.js
@@ -190,7 +190,7 @@ const xml = function() {
       return jstoxml.toXML(
         {
           CopyObjectResult: {
-            LastModified: item.modifiedDate.toISOString(),
+            LastModified: new Date(item.modifiedDate).toISOString(),
             ETag: '"' + item.md5 + '"'
           }
         },

--- a/test/test.js
+++ b/test/test.js
@@ -418,6 +418,7 @@ describe("S3rver Tests", function() {
           Bucket: buckets[3],
           Key: destKey,
           CopySource: "/" + buckets[0] + "/" + srcKey,
+          MetadataDirective: "REPLACE",
           Metadata: {
             someKey: "value"
           }


### PR DESCRIPTION
I've actually encountered this and worked around it thinking it was just some annoying behavior for S3, but it's actually just been implemented wrong here. Ideally this would have been caught a long time ago since it's basically the result of a syntax error, but `var` is just the best at hiding those -_-.

I'm still working on rebasing the fs store refactor I've had for a while now that has a much better implementation of this with proper error handling, but I'll add this now just since there's some value in giving new test cases their own PR.