### PR TITLE
Use modern ES features where applicable

### DIFF
--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 "use strict";
-const pkg = require("../package.json");
-const version = pkg.version;
-const program = require("commander");
-const fs = require("fs-extra");
-const S3rver = require("../lib");
 
-program.version(version, "--version");
+const fs = require("fs-extra");
+const program = require("commander");
+const pkg = require("../package.json");
+const S3rver = require("..");
+
+program.version(pkg.version, "--version");
 program
   .option(
     "-h, --hostname [value]",

--- a/lib/app.js
+++ b/lib/app.js
@@ -4,7 +4,7 @@ const express = require("express");
 const morgan = require("morgan");
 const path = require("path");
 
-const Controllers = require("./controllers");
+const controllers = require("./controllers");
 const cors = require("./cors");
 const createLogger = require("./logger");
 const Subject = require("rxjs/Subject").Subject;
@@ -20,14 +20,14 @@ module.exports = function(options) {
   app.use(
     morgan("tiny", {
       stream: {
-        write: function(message) {
+        write(message) {
           app.logger.info(message.slice(0, -1));
         }
       }
     })
   );
 
-  app.use(function(req, res, next) {
+  app.use((req, res, next) => {
     const host = req.headers.host.split(":")[0];
 
     // Handle requests for <bucket>.s3(-<region>?).amazonaws.com, if they arrive.
@@ -51,7 +51,7 @@ module.exports = function(options) {
 
   // Don't register logger until app is successfully set up
   app.logger = createLogger(options.silent);
-  const controllers = new Controllers(
+  const middleware = controllers(
     options.directory,
     app.logger,
     options.indexDocument,
@@ -61,24 +61,20 @@ module.exports = function(options) {
   /**
    * Routes for the application
    */
-  app.get("/", controllers.getBuckets);
-  app.get("/:bucket", controllers.bucketExists, controllers.getBucket);
-  app.delete("/:bucket", controllers.bucketExists, controllers.deleteBucket);
-  app.put("/:bucket", controllers.putBucket);
-  app.put("/:bucket/:key(*)", controllers.bucketExists, controllers.putObject);
-  app.post(
-    "/:bucket/:key(*)",
-    controllers.bucketExists,
-    controllers.postObject
-  );
-  app.get("/:bucket/:key(*)", controllers.bucketExists, controllers.getObject);
-  app.head("/:bucket/:key(*)", controllers.getObject);
+  app.get("/", middleware.getBuckets);
+  app.get("/:bucket", middleware.bucketExists, middleware.getBucket);
+  app.delete("/:bucket", middleware.bucketExists, middleware.deleteBucket);
+  app.put("/:bucket", middleware.putBucket);
+  app.put("/:bucket/:key(*)", middleware.bucketExists, middleware.putObject);
+  app.post("/:bucket/:key(*)", middleware.bucketExists, middleware.postObject);
+  app.get("/:bucket/:key(*)", middleware.bucketExists, middleware.getObject);
+  app.head("/:bucket/:key(*)", middleware.getObject);
   app.delete(
     "/:bucket/:key(*)",
-    controllers.bucketExists,
-    controllers.deleteObject
+    middleware.bucketExists,
+    middleware.deleteObject
   );
-  app.post("/:bucket", controllers.bucketExists, controllers.genericPost);
+  app.post("/:bucket", middleware.bucketExists, middleware.genericPost);
 
   return app;
 };

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -1,28 +1,39 @@
 "use strict";
 
-const FileStore = require("./file-store");
-const templateBuilder = require("./xml-template-builder");
-const concat = require("concat-stream");
-const xml2js = require("xml2js");
 const async = require("async");
-const path = require("path");
-const ReadableStream = require("stream").Readable;
+const concat = require("concat-stream");
 const crypto = require("crypto");
+const path = require("path");
+const { Readable: ReadableStream } = require("stream");
 const url = require("url");
+const xml2js = require("xml2js");
+
+const FileStore = require("./file-store");
 const S3Event = require("./models/s3-event");
+const templateBuilder = require("./xml-template-builder");
 
 module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
   const fileStore = new FileStore(rootDirectory);
 
-  const buildXmlResponse = function(res, status, template) {
+  function buildXmlResponse(res, status, template) {
     res.header("Content-Type", "application/xml");
     res.status(status);
     return res.send(template);
-  };
+  }
 
-  const buildResponse = function(req, res, status, object, data) {
-    res.header("Etag", '"' + object.md5 + '"');
-    res.header("Last-Modified", new Date(object.modifiedDate).toUTCString());
+  function buildResponse(req, res, status, object, data) {
+    res.header("Accept-Ranges", "bytes");
+    if (data.range) {
+      const end = Math.min(data.range.end || Infinity, object.size - 1);
+      res.header(
+        "Content-Range",
+        "bytes " + data.range.start + "-" + end + "/" + object.size
+      );
+      res.header("Content-Length", end - data.range.start + 1);
+    } else {
+      res.header("Content-Length", object.size);
+    }
+
     res.setHeader("Content-Type", object.contentType);
 
     if (object.contentEncoding)
@@ -31,40 +42,33 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
     if (object.contentDisposition)
       res.header("Content-Disposition", object.contentDisposition);
 
-    if (data.range) {
-      var end = Math.min(data.range.end || Infinity, object.size - 1);
-      res.header(
-        "Content-Range",
-        "bytes " + data.range.start + "-" + end + "/" + object.size
-      );
-      res.header("Accept-Ranges", "bytes");
-      res.header("Content-Length", end - data.range.start + 1);
-    } else {
-      res.header("Content-Length", object.size);
-    }
+    res.header("Etag", JSON.stringify(object.md5));
+    res.header("Last-Modified", new Date(object.modifiedDate).toUTCString());
 
     if (object.customMetaData.length > 0) {
-      object.customMetaData.forEach(function(metaData) {
-        res.header(metaData.key, metaData.value);
-      });
+      for (const { key, value } of object.customMetaData) {
+        res.header(key, value);
+      }
     }
     res.status(status);
-    if (req.method === "HEAD") {
-      return res.end();
-    }
-    return data.pipe(res);
-  };
 
-  const triggerS3Event = function(req, res, eventData) {
+    if (req.method === "HEAD") {
+      res.end();
+    } else {
+      data.pipe(res);
+    }
+  }
+
+  function triggerS3Event(req, res, eventData) {
     res.app.s3Event.next(
       new S3Event(eventData, {
         reqHeaders: req.headers,
         sourceIp: req.connection.remoteAddress
       })
     );
-  };
+  }
 
-  const errorResponse = function(req, res, keyName) {
+  function errorResponse(req, res, keyName) {
     logger.error(
       'Object "%s" in bucket "%s" does not exist',
       keyName,
@@ -73,11 +77,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
 
     if (indexDocument) {
       if (errorDocument) {
-        fileStore.getObject(req.bucket, errorDocument, function(
-          err,
-          object,
-          data
-        ) {
+        fileStore.getObject(req.bucket, errorDocument, (err, object, data) => {
           if (err) {
             // eslint-disable-next-line no-console
             console.error("Custom Error Document not found: " + errorDocument);
@@ -93,9 +93,9 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
       const template = templateBuilder.buildKeyNotFound(keyName);
       return buildXmlResponse(res, 404, template);
     }
-  };
+  }
 
-  const notFoundResponse = function(req, res) {
+  function notFoundResponse(req, res) {
     const ErrorDoc =
       "<!DOCTYPE html>\n<html><head><title>404 - Resource Not Found</title></head><body><h1>404 - Resource Not Found</h1></body></html>";
     const stream = new ReadableStream();
@@ -114,21 +114,18 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
       },
       stream
     );
-  };
+  }
 
-  const deleteObjects = function(req, res) {
-    xml2js.parseString(req.body, function(err, parsedBody) {
-      const keys = parsedBody.Delete.Object.map(function(o) {
-        return o.Key[0];
-      });
+  function deleteObjects(req, res) {
+    xml2js.parseString(req.body, (err, parsedBody) => {
+      const keys = parsedBody.Delete.Object.map(o => o.Key[0]);
       async.each(
         keys,
-        function(key, cb) {
-          fileStore.getObjectExists(req.bucket, key, function(err) {
-            if (err) {
-              return cb();
-            }
-            fileStore.deleteObject(req.bucket, key, function(err) {
+        (key, cb) => {
+          fileStore.getObjectExists(req.bucket, key, err => {
+            if (err) return cb();
+
+            fileStore.deleteObject(req.bucket, key, err => {
               if (err) {
                 logger.error('Could not delete object "%s"', key, err);
                 const template = templateBuilder.buildError(
@@ -147,29 +144,29 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
             });
           });
         },
-        function(err) {
+        err => {
           if (err) return;
           const template = templateBuilder.buildObjectsDeleted(keys);
           return buildXmlResponse(res, 200, template);
         }
       );
     });
-  };
+  }
 
-  const handleCopyObject = function(key, req, res) {
+  function handleCopyObject(key, req, res) {
     let template;
     let copy = req.headers["x-amz-copy-source"];
     copy = copy.charAt(0) === "/" ? copy : "/" + copy;
     const srcObjectParams = copy.split("/"),
       srcBucket = srcObjectParams[1],
       srcObject = srcObjectParams.slice(2).join("/");
-    fileStore.getBucket(srcBucket, function(err, bucket) {
+    fileStore.getBucket(srcBucket, (err, bucket) => {
       if (err) {
         logger.error('No bucket found for "%s"', srcBucket);
         template = templateBuilder.buildBucketNotFound(srcBucket);
         return buildXmlResponse(res, 404, template);
       }
-      fileStore.getObject(bucket, srcObject, function(err) {
+      fileStore.getObject(bucket, srcObject, err => {
         if (err) {
           logger.error(
             'Object "%s" in bucket "%s" does not exist',
@@ -191,7 +188,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
             destKey: key,
             replaceMetadata: replaceMetadata
           },
-          function(err, object) {
+          (err, object) => {
             if (err) {
               logger.error(
                 'Error copying object "%s" from bucket "%s" into bucket "%s" with key of "%s"',
@@ -225,14 +222,14 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         );
       });
     });
-  };
+  }
 
-  const putObjectMultipart = function(req, res) {
+  function putObjectMultipart(req, res) {
     const partKey = req.query.uploadId + "_" + req.query.partNumber;
     if (req.headers["x-amz-copy-source"]) {
       handleCopyObject(partKey, req, res);
     } else {
-      fileStore.putObject(req.bucket, partKey, req, function(err, key) {
+      fileStore.putObject(req.bucket, partKey, req, (err, key) => {
         if (err) {
           logger.error(
             'Error uploading object "%s" to bucket "%s"',
@@ -251,11 +248,11 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
           partKey,
           req.bucket.name
         );
-        res.header("ETag", '"' + key.md5 + '"');
+        res.header("ETag", JSON.stringify(key.md5));
         return res.status(200).end();
       });
     }
-  };
+  }
 
   /**
    * The following methods correspond the S3 api. For more information visit:
@@ -265,25 +262,27 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
     /**
      * Middleware to check if a bucket exists
      */
-    bucketExists: function(req, res, next) {
+    bucketExists(req, res, next) {
       const bucketName = req.params.bucket;
-      fileStore.getBucket(bucketName, function(err, bucket) {
+      fileStore.getBucket(bucketName, (err, bucket) => {
         if (err) {
           logger.error('No bucket found for "%s"', bucketName);
           const template = templateBuilder.buildBucketNotFound(bucketName);
           return buildXmlResponse(res, 404, template);
         }
         req.bucket = bucket;
-        return next();
+        next();
       });
     },
-    getBuckets: function(req, res) {
+
+    getBuckets(req, res) {
       const buckets = fileStore.getBuckets();
       logger.info("Fetched %d buckets", buckets.length);
       const template = templateBuilder.buildBuckets(buckets);
       return buildXmlResponse(res, 200, template);
     },
-    getBucket: function(req, res) {
+
+    getBucket(req, res) {
       const options = {
         bucketName: req.bucket.name || null,
         marker: req.query.marker || null,
@@ -293,17 +292,10 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
       };
 
       if (indexDocument) {
-        fileStore.getObject(req.bucket, indexDocument, function(
-          err,
-          object,
-          data
-        ) {
-          if (err) {
-            return errorResponse(req, res, indexDocument);
-          } else {
-            logger.info("Serving Page: %s", object.key);
-            return buildResponse(req, res, 200, object, data);
-          }
+        fileStore.getObject(req.bucket, indexDocument, (err, object, data) => {
+          if (err) return errorResponse(req, res, indexDocument);
+          logger.info("Serving Page: %s", object.key);
+          buildResponse(req, res, 200, object, data);
         });
       } else {
         logger.info(
@@ -311,7 +303,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
           req.bucket.name,
           options
         );
-        fileStore.getObjects(req.bucket, options, function(err, results) {
+        fileStore.getObjects(req.bucket, options, (err, results) => {
           logger.info(
             'Found %d objects for bucket "%s"',
             results.objects.length,
@@ -322,7 +314,8 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         });
       }
     },
-    putBucket: function(req, res) {
+
+    putBucket(req, res) {
       const bucketName = req.params.bucket;
       let template;
       /**
@@ -351,7 +344,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         );
         return buildXmlResponse(res, 400, template);
       }
-      fileStore.getBucket(bucketName, function(err, bucket) {
+      fileStore.getBucket(bucketName, (err, bucket) => {
         if (bucket) {
           logger.error(
             'Error creating bucket. Bucket "%s" already exists',
@@ -363,7 +356,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
           );
           return buildXmlResponse(res, 409, template);
         }
-        fileStore.putBucket(bucketName, function(err) {
+        fileStore.putBucket(bucketName, err => {
           if (err) {
             logger.error('Error creating bucket "%s"', err);
             const template = templateBuilder.buildError(
@@ -378,8 +371,9 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         });
       });
     },
-    deleteBucket: function(req, res) {
-      fileStore.deleteBucket(req.bucket, function(err) {
+
+    deleteBucket(req, res) {
+      fileStore.deleteBucket(req.bucket, err => {
         if (err) {
           const template = templateBuilder.buildBucketNotEmpty(req.bucket.name);
           return buildXmlResponse(res, 409, template);
@@ -387,63 +381,66 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         return res.status(204).end();
       });
     },
-    getObject: function(req, res) {
+
+    getObject(req, res) {
       let keyName = req.params.key;
       const acl = req.query.acl;
       if (acl !== undefined) {
         const template = templateBuilder.buildAcl();
         return buildXmlResponse(res, 200, template);
       }
-      fileStore.getObject(req.bucket, keyName, req.headers.range, function(
-        err,
-        object,
-        data
-      ) {
-        if (err) {
-          if (indexDocument) {
-            keyName = path.join(keyName, indexDocument);
-            return fileStore.getObject(req.bucket, keyName, function(
-              err,
-              object,
-              data
-            ) {
-              if (err) {
-                return errorResponse(req, res, keyName);
-              } else {
-                return buildResponse(req, res, 200, object, data);
-              }
-            });
-          } else {
-            return errorResponse(req, res, keyName);
+      fileStore.getObject(
+        req.bucket,
+        keyName,
+        req.headers.range,
+        (err, object, data) => {
+          if (err) {
+            if (indexDocument) {
+              keyName = path.join(keyName, indexDocument);
+              return fileStore.getObject(
+                req.bucket,
+                keyName,
+                (err, object, data) => {
+                  if (err) {
+                    return errorResponse(req, res, keyName);
+                  } else {
+                    return buildResponse(req, res, 200, object, data);
+                  }
+                }
+              );
+            } else {
+              return errorResponse(req, res, keyName);
+            }
           }
-        }
 
-        const noneMatch = req.headers["if-none-match"];
-        if (
-          noneMatch &&
-          (noneMatch === '"' + object.md5 + '"' || noneMatch === "*")
-        ) {
-          return res.status(304).end();
-        }
-        const modifiedSince = req.headers["if-modified-since"];
-        if (modifiedSince) {
-          const time = new Date(modifiedSince);
-          const modifiedDate = new Date(object.modifiedDate);
-          if (time >= modifiedDate) {
+          const noneMatch = req.headers["if-none-match"];
+          if (
+            noneMatch &&
+            (noneMatch === JSON.stringify(object.md5) || noneMatch === "*")
+          ) {
             return res.status(304).end();
           }
-        }
+          const modifiedSince = req.headers["if-modified-since"];
+          if (modifiedSince) {
+            const time = new Date(modifiedSince);
+            const modifiedDate = new Date(object.modifiedDate);
+            if (time >= modifiedDate) {
+              return res.status(304).end();
+            }
+          }
 
-        return buildResponse(
-          req,
-          res,
-          req.headers.range ? 206 : 200,
-          object,
-          data
-        );
-      });
+          return buildResponse(
+            req,
+            res,
+            req.headers.range ? 206 : 200,
+            object,
+            data
+          );
+        }
+      );
     },
-    putObject: function(req, res) {
+
+    putObject(req, res) {
       if (req.query.uploadId) {
         return putObjectMultipart(req, res);
       }
@@ -451,10 +448,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
       if (req.headers["x-amz-copy-source"]) {
         handleCopyObject(req.params.key, req, res);
       } else {
-        fileStore.putObject(req.bucket, req.params.key, req, function(
-          err,
-          key
-        ) {
+        fileStore.putObject(req.bucket, req.params.key, req, (err, key) => {
           if (err) {
             logger.error(
               'Error uploading object "%s" to bucket "%s"',
@@ -478,14 +472,15 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
             eventType: "Put",
             S3Item: key
           });
-          res.header("ETag", '"' + key.md5 + '"');
+          res.header("ETag", JSON.stringify(key.md5));
           return res.status(200).end();
         });
       }
     },
-    postObject: function(req, res) {
+
+    postObject(req, res) {
       if (req.query.uploads !== undefined) {
-        var uploadId = crypto.randomBytes(16).toString("hex");
+        const uploadId = crypto.randomBytes(16).toString("hex");
         return buildXmlResponse(
           res,
           200,
@@ -498,12 +493,12 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
       } else {
         let completeMultipartUploadXml = "";
 
-        req.on("data", function(data) {
+        req.on("data", data => {
           completeMultipartUploadXml += data.toString("utf8");
         });
 
-        req.on("end", function() {
-          xml2js.parseString(completeMultipartUploadXml, function(err, result) {
+        req.on("end", () => {
+          xml2js.parseString(completeMultipartUploadXml, (err, result) => {
             if (err) {
               logger.error(
                 'Error completing multipart upload "%s" for object "%s" in bucket "%s"',
@@ -519,14 +514,10 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
               return buildXmlResponse(res, 400, template);
             }
 
-            const parts = result.CompleteMultipartUpload.Part.map(function(
-              part
-            ) {
-              return {
-                number: part.PartNumber[0],
-                etag: part.ETag[0].replace('"', "")
-              };
-            });
+            const parts = result.CompleteMultipartUpload.Part.map(part => ({
+              number: part.PartNumber[0],
+              etag: JSON.parse(part.ETag[0])
+            }));
 
             fileStore.combineObjectParts(
               req.bucket,
@@ -534,7 +525,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
               req.query.uploadId,
               parts,
               req,
-              function(err, key) {
+              (err, key) => {
                 if (err) {
                   logger.error(
                     'Error uploading object "%s" to bucket "%s"',
@@ -579,13 +570,14 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         });
       }
     },
-    deleteObject: function(req, res) {
+
+    deleteObject(req, res) {
       const key = req.params.key;
-      fileStore.getObjectExists(req.bucket, key, function(err) {
+      fileStore.getObjectExists(req.bucket, key, err => {
         if (err) {
           return res.status(204).end();
         }
-        fileStore.deleteObject(req.bucket, key, function(err) {
+        fileStore.deleteObject(req.bucket, key, err => {
           if (err) {
             logger.error('Could not delete object "%s"', key, err);
             const template = templateBuilder.buildError(
@@ -608,15 +600,18 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         });
       });
     },
-    genericPost: function(req, res) {
-      if (req.query.delete !== undefined)
+
+    genericPost(req, res) {
+      if (req.query.delete !== undefined) {
         req.pipe(
-          concat(function(data) {
+          concat(data => {
             req.body = data;
             deleteObjects(req, res);
           })
         );
-      else notFoundResponse(req, res);
+      } else {
+        notFoundResponse(req, res);
+      }
     }
   };
 };

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -1,123 +1,174 @@
 "use strict";
 
-const path = require("path");
 const async = require("async");
 const crypto = require("crypto");
-const PassThrough = require("stream").PassThrough;
-const utils = require("./utils");
-const _ = require("lodash");
 const fs = require("fs-extra");
+const { sortBy } = require("lodash");
+const path = require("path");
+const { PassThrough } = require("stream");
 
-const FileStore = function(rootDirectory) {
-  const CONTENT_FILE = ".dummys3_content",
-    METADATA_FILE = ".dummys3_metadata",
-    Bucket = require("./models/bucket"),
-    S3Object = require("./models/s3-object");
-  const getBucketPath = function(bucketName) {
-    return path.join(rootDirectory, bucketName).replace(/\\/g, "/");
-  };
+const Bucket = require("./models/bucket");
+const S3Object = require("./models/s3-object");
+const utils = require("./utils");
 
-  const getBucket = function(bucketName, done) {
-    const bucketPath = getBucketPath(bucketName);
-    fs.stat(bucketPath, function(err, file) {
+const CONTENT_FILE = ".dummys3_content";
+const METADATA_FILE = ".dummys3_metadata";
+
+class FileStore {
+  constructor(rootDirectory) {
+    this.rootDirectory = rootDirectory;
+  }
+
+  // helpers
+  getBucketPath(bucketName) {
+    return path.join(this.rootDirectory, bucketName);
+  }
+
+  buildS3ObjectFromMetaDataFile(key, file) {
+    const json = JSON.parse(file);
+    const metaData = {
+      key: key,
+      md5: json.md5,
+      contentType: json.contentType,
+      contentEncoding: json.contentEncoding,
+      contentDisposition: json.contentDisposition,
+      size: json.size,
+      modifiedDate: json.modifiedDate,
+      creationDate: json.creationDate,
+      customMetaData: json.customMetaData
+    };
+    return new S3Object(metaData);
+  }
+
+  getCustomMetaData(headers) {
+    const customMetaData = [];
+    for (const header in headers) {
+      if (header.startsWith("x-amz-meta-")) {
+        customMetaData.push({
+          key: header,
+          value: headers[header]
+        });
+      }
+    }
+    return customMetaData;
+  }
+
+  createMetaData(
+    { key, contentFile, metaFile, type, encoding, disposition, headers },
+    done
+  ) {
+    async.parallel(
+      [
+        callback => fs.stat(contentFile, callback),
+        callback => {
+          let length = 0;
+          const md5 = crypto.createHash("md5");
+          const stream = fs.createReadStream(contentFile);
+
+          stream.on("error", err => {
+            return callback(err);
+          });
+
+          stream.on("data", data => {
+            length += data.length;
+            md5.update(data, "utf8");
+          });
+
+          stream.on("end", () => {
+            return callback(null, {
+              size: length,
+              md5: md5.digest("hex")
+            });
+          });
+        }
+      ],
+      (err, results) => {
+        const metaData = {
+          key: key,
+          creationDate: results[0].ctime,
+          modifiedDate: results[0].mtime,
+          md5: results[1].md5,
+          size: results[1].size,
+          customMetaData: this.getCustomMetaData(headers)
+        };
+        if (type) metaData.contentType = type;
+        if (encoding) metaData.contentEncoding = encoding;
+        if (disposition) metaData.contentDisposition = disposition;
+
+        fs.writeFile(metaFile, JSON.stringify(metaData), err => {
+          if (err) return done(err);
+          done(null, metaData);
+        });
+      }
+    );
+  }
+
+  getObjectExists(bucket, key, done) {
+    const keyPath = path.resolve(this.getBucketPath(bucket.name), key);
+    fs.stat(keyPath, (err, file) => {
       if (err || !file.isDirectory()) {
-        return done("Bucket not found");
+        return done("Object not found for " + keyPath);
       }
-      return done(null, new Bucket(bucketName, file.ctime));
+      done();
     });
-  };
+  }
 
-  const deleteBucket = function(bucket, done) {
-    const bucketPath = getBucketPath(bucket.name);
-    fs.rmdir(bucketPath, function(err) {
-      if (err) {
-        return done(err);
-      }
-      return done();
+  concatStreams(passThrough, streams) {
+    const stream = streams.shift();
+    if (!stream) {
+      passThrough.end();
+      return passThrough;
+    }
+    stream.once("end", () => {
+      this.concatStreams(passThrough, streams);
     });
-  };
+    stream.pipe(passThrough, { end: false });
+    return passThrough;
+  }
 
-  const getBuckets = function() {
+  // store implementation
+
+  getBuckets() {
     const buckets = [];
-    fs.readdirSync(rootDirectory).filter(function(result) {
-      const file = fs.statSync(path.resolve(rootDirectory, result));
+    fs.readdirSync(this.rootDirectory).filter(result => {
+      const file = fs.statSync(path.resolve(this.rootDirectory, result));
       if (file.isDirectory()) {
         buckets.push(new Bucket(result, file.ctime));
       }
     });
     return buckets;
-  };
+  }
 
-  const putBucket = function(bucketName, done) {
-    const bucketPath = getBucketPath(bucketName);
-    fs.mkdirp(bucketPath, 502, function(err) {
-      if (err) {
-        return done(err);
+  getBucket(bucketName, done) {
+    const bucketPath = this.getBucketPath(bucketName);
+    fs.stat(bucketPath, (err, file) => {
+      if (err || !file.isDirectory()) {
+        return done("Bucket not found");
       }
-      return getBucket(bucketName, done);
+      done(null, new Bucket(bucketName, file.ctime));
     });
-  };
+  }
 
-  const getObject = function(bucket, key, range, done) {
-    if (typeof range === "function") {
-      done = range;
-      range = null;
-    }
-    const filePath = path.resolve(getBucketPath(bucket.name), key);
-    fs.stat(filePath, function(err) {
-      if (err && err.code === "ENOENT") {
-        return done("Not found");
-      }
-      const options = {};
-      if (range) {
-        const positions = range.replace(/bytes=/, "").split("-");
-        options.start = parseInt(positions[0], 10);
-        if (positions[1]) options.end = parseInt(positions[1], 10);
-      }
-      async.parallel(
-        [
-          function(callback) {
-            const readStream = fs.createReadStream(
-              path.join(filePath, CONTENT_FILE),
-              options
-            );
-            readStream.range = range && options;
-            readStream.on("error", function(err) {
-              return callback(err);
-            });
-            readStream.on("open", function() {
-              return callback(null, readStream);
-            });
-          },
-          function(callback) {
-            fs.readFile(path.join(filePath, METADATA_FILE), function(
-              err,
-              data
-            ) {
-              if (err) {
-                return callback(err);
-              }
-              callback(null, buildS3ObjectFromMetaDataFile(key, data));
-            });
-          }
-        ],
-        function(err, results) {
-          if (err) {
-            return done(err);
-          }
-          return done(null, results[1], results[0]);
-        }
-      );
+  putBucket(bucketName, done) {
+    const bucketPath = this.getBucketPath(bucketName);
+    fs.mkdirp(bucketPath, 502, err => {
+      if (err) return done(err);
+      this.getBucket(bucketName, done);
     });
-  };
+  }
 
-  const getObjects = function(bucket, options, done) {
-    const bucketPath = getBucketPath(bucket.name);
+  deleteBucket(bucket, done) {
+    const bucketPath = this.getBucketPath(bucket.name);
+    fs.rmdir(bucketPath, done);
+  }
+
+  getObjects(bucket, options, done) {
+    const bucketPath = this.getBucketPath(bucket.name);
     const objects = [];
     const commonPrefixes = [];
     const keys = utils.walk(bucketPath);
 
-    if (keys.length === 0) {
+    if (!keys.length) {
       return done(null, {
         objects: [],
         commonPrefixes: []
@@ -125,9 +176,8 @@ const FileStore = function(rootDirectory) {
     }
 
     let filteredKeys = [];
-
     if (options.delimiter && options.prefix) {
-      _.forEach(keys, function(key) {
+      for (const key of keys) {
         const truncatedKey = key.replace(bucketPath + "/", "");
         if (truncatedKey.slice(0, options.prefix.length) == options.prefix) {
           if (
@@ -149,16 +199,16 @@ const FileStore = function(rootDirectory) {
             filteredKeys.push(key);
           }
         }
-      });
+      }
     } else if (options.prefix) {
-      _.forEach(keys, function(key) {
+      for (const key of keys) {
         const truncatedKey = key.replace(bucketPath + "/", "");
         if (truncatedKey.slice(0, options.prefix.length) == options.prefix) {
           filteredKeys.push(key);
         }
-      });
+      }
     } else if (options.delimiter) {
-      _.forEach(keys, function(key) {
+      for (const key of keys) {
         const truncatedKey = key.replace(bucketPath + "/", "");
         if (truncatedKey.indexOf(options.delimiter) > -1) {
           const commonPrefix = truncatedKey.substring(
@@ -172,7 +222,7 @@ const FileStore = function(rootDirectory) {
         } else {
           filteredKeys.push(key);
         }
-      });
+      }
     } else {
       filteredKeys = keys;
     }
@@ -181,7 +231,7 @@ const FileStore = function(rootDirectory) {
     if (options.marker) {
       let startAt = 0;
       let found = false;
-      _.each(filteredKeys, function(key, index) {
+      filteredKeys.forEach((key, index) => {
         if (options.marker == key.replace(bucketPath + "/", "")) {
           startAt = index + 1;
           found = true;
@@ -194,12 +244,12 @@ const FileStore = function(rootDirectory) {
 
     async.eachSeries(
       filteredKeys,
-      function(key, callback) {
+      (key, callback) => {
         key = key.replace(/\\/g, "/");
-        fs.readFile(path.join(key, METADATA_FILE), function(err, data) {
+        fs.readFile(path.join(key, METADATA_FILE), (err, data) => {
           if (!err) {
             objects.push(
-              buildS3ObjectFromMetaDataFile(
+              this.buildS3ObjectFromMetaDataFile(
                 key.replace(bucketPath + "/", ""),
                 data
               )
@@ -208,122 +258,62 @@ const FileStore = function(rootDirectory) {
           callback();
         });
       },
-      function() {
-        return done(null, {
-          objects: objects,
-          commonPrefixes: commonPrefixes
-        });
-      }
+      () => done(null, { objects, commonPrefixes })
     );
-  };
+  }
 
-  const buildS3ObjectFromMetaDataFile = function(key, file) {
-    const json = JSON.parse(file);
-    const metaData = {
-      key: key,
-      md5: json.md5,
-      contentType: json.contentType,
-      contentEncoding: json.contentEncoding,
-      contentDisposition: json.contentDisposition,
-      size: json.size,
-      modifiedDate: json.modifiedDate,
-      creationDate: json.creationDate,
-      customMetaData: json.customMetaData
-    };
-    return new S3Object(metaData);
-  };
-
-  const getCustomMetaData = function(headers) {
-    const customMetaData = [];
-    for (const header in headers) {
-      if (/^x-amz-meta-(.*)$/.test(header)) {
-        customMetaData.push({
-          key: header,
-          value: headers[header]
-        });
-      }
+  getObject(bucket, key, range, done) {
+    if (typeof range === "function") {
+      done = range;
+      range = null;
     }
-    return customMetaData;
-  };
+    const filePath = path.resolve(this.getBucketPath(bucket.name), key);
+    fs.stat(filePath, err => {
+      if (err && err.code === "ENOENT") return done("Not found");
 
-  const createMetaData = function(data, done) {
-    const contentFile = data.contentFile,
-      type = data.type,
-      encoding = data.encoding,
-      disposition = data.disposition,
-      metaFile = data.metaFile,
-      headers = data.headers;
-    async.parallel(
-      [
-        function(callback) {
-          fs.stat(contentFile, function(err, stats) {
-            if (err) {
-              return callback(err);
-            }
-            return callback(null, {
-              mtime: stats.mtime,
-              ctime: stats.ctime
-            });
-          });
-        },
-        function(callback) {
-          let length = 0;
-          const md5 = crypto.createHash("md5");
-          const stream = fs.createReadStream(contentFile);
-
-          stream.on("error", function(err) {
-            return callback(err);
-          });
-
-          stream.on("data", function(data) {
-            length += data.length;
-            md5.update(data, "utf8");
-          });
-
-          stream.on("end", function() {
-            return callback(null, {
-              size: length,
-              md5: md5.digest("hex")
-            });
-          });
-        }
-      ],
-      function(err, results) {
-        const metaData = {
-          key: data.key,
-          md5: results[1].md5,
-          size: results[1].size,
-          modifiedDate: results[0].mtime,
-          creationDate: results[0].ctime,
-          customMetaData: getCustomMetaData(headers)
-        };
-        if (type) metaData.contentType = type;
-        if (encoding) metaData.contentEncoding = encoding;
-        if (disposition) metaData.contentDisposition = disposition;
-
-        fs.writeFile(metaFile, JSON.stringify(metaData), function(err) {
-          if (err) {
-            return done(err);
-          }
-          return done(null, metaData);
-        });
+      const options = {};
+      if (range && range.startsWith("bytes=")) {
+        const [start, end] = range.replace("bytes=", "").split("-");
+        options.start = parseInt(start, 10);
+        if (end) options.end = parseInt(end, 10);
       }
-    );
-  };
+      async.parallel(
+        [
+          callback => {
+            const readStream = fs.createReadStream(
+              path.join(filePath, CONTENT_FILE),
+              options
+            );
+            readStream.range = range && options;
+            readStream.on("error", callback);
+            readStream.on("open", () => callback(null, readStream));
+          },
+          callback => {
+            fs.readFile(path.join(filePath, METADATA_FILE), (err, data) => {
+              if (err) return callback(err);
+              callback(null, this.buildS3ObjectFromMetaDataFile(key, data));
+            });
+          }
+        ],
+        (err, results) => {
+          if (err) return done(err);
+          return done(null, results[1], results[0]);
+        }
+      );
+    });
+  }
 
-  const putObject = function(bucket, key, req, done) {
+  putObject(bucket, key, req, done) {
     const keyName = path.join(bucket.name, key);
-    const dirName = path.join(rootDirectory, keyName);
+    const dirName = path.join(this.rootDirectory, keyName);
     fs.mkdirpSync(dirName);
     const contentFile = path.join(dirName, CONTENT_FILE);
     const metaFile = path.join(dirName, METADATA_FILE);
     const writeStream = req.pipe(fs.createWriteStream(contentFile));
-    writeStream.on("error", function() {
-      return done("Error writing file");
-    });
-    writeStream.on("close", function() {
+    writeStream.on("error", done);
+    writeStream.on("close", () => {
       writeStream.end();
-      createMetaData(
+      this.createMetaData(
         {
           contentFile: contentFile,
           type: req.headers["content-type"],
@@ -333,29 +323,24 @@ const FileStore = function(rootDirectory) {
           metaFile: metaFile,
           headers: req.headers
         },
-        function(err, metaData) {
-          if (err) {
-            return done("Error uploading file");
-          }
-          return done(null, new S3Object(metaData));
+        (err, metaData) => {
+          if (err) return done("Error uploading file");
+          done(null, new S3Object(metaData));
         }
       );
     });
-  };
+  }
 
-  const copyObject = function(options, done) {
-    const req = options.request;
-    const srcBucket = options.srcBucket;
-    const srcKey = options.srcKey;
-    const destBucket = options.destBucket;
-    const destKey = options.destKey;
-    const srcKeyPath = path.resolve(getBucketPath(srcBucket.name), srcKey);
-    const destKeyPath = path.resolve(getBucketPath(destBucket.name), destKey);
-    const replaceMetadata = options.replaceMetadata;
-    const srcMetadataFilePath = path.join(srcKeyPath, METADATA_FILE);
+  copyObject(
+    { request, srcBucket, srcKey, destBucket, destKey, replaceMetadata },
+    done
+  ) {
+    const srcKeyPath = path.join(this.getBucketPath(srcBucket.name), srcKey);
+    const destKeyPath = path.join(this.getBucketPath(destBucket.name), destKey);
     const srcContentFilePath = path.join(srcKeyPath, CONTENT_FILE);
-    const destMetadataFilePath = path.join(destKeyPath, METADATA_FILE);
+    const srcMetadataFilePath = path.join(srcKeyPath, METADATA_FILE);
     const destContentFilePath = path.join(destKeyPath, CONTENT_FILE);
+    const destMetadataFilePath = path.join(destKeyPath, METADATA_FILE);
 
     if (srcKeyPath !== destKeyPath) {
       fs.mkdirpSync(destKeyPath);
@@ -363,142 +348,95 @@ const FileStore = function(rootDirectory) {
     }
 
     if (replaceMetadata) {
-      const originalObject = buildS3ObjectFromMetaDataFile(
+      const originalObject = this.buildS3ObjectFromMetaDataFile(
         srcKey,
         fs.readFileSync(srcMetadataFilePath)
       );
-      createMetaData(
+      this.createMetaData(
         {
+          key: destKey,
           contentFile: destContentFilePath,
+          metaFile: destMetadataFilePath,
           type: originalObject.contentType,
           encoding: originalObject.contentEncoding,
           disposition: originalObject.contentDisposition,
-          key: destKey,
-          metaFile: destMetadataFilePath,
-          headers: req.headers
+          headers: request.headers
         },
-        function(err, metaData) {
-          if (err) {
-            return done("Error updating metadata");
-          }
-          return done(null, new S3Object(metaData));
+        (err, metaData) => {
+          if (err) return done("Error updating metadata");
+          done(null, new S3Object(metaData));
         }
       );
-    } else {
+    } else if (srcKeyPath !== destKeyPath) {
       fs.copySync(srcMetadataFilePath, destMetadataFilePath);
-      fs.readFile(destMetadataFilePath, function(err, data) {
-        if (err) {
-          return done(err);
-        }
-        done(null, buildS3ObjectFromMetaDataFile(destKey, data));
+      fs.readFile(destMetadataFilePath, (err, data) => {
+        if (err) return done(err);
+        done(null, this.buildS3ObjectFromMetaDataFile(destKey, data));
       });
     }
-  };
+  }
 
-  const deleteObject = function(bucket, key, done) {
-    const bucketPath = getBucketPath(bucket.name);
+  deleteObject(bucket, key, done) {
+    const bucketPath = this.getBucketPath(bucket.name);
     const keyPath = path.resolve(bucketPath, key);
     async.map(
-      [path.join(keyPath, METADATA_FILE), path.join(keyPath, CONTENT_FILE)],
+      [path.join(keyPath, CONTENT_FILE), path.join(keyPath, METADATA_FILE)],
       fs.unlink,
-      function(err) {
-        if (err) {
-          return done(err);
-        }
-        fs.rmdir(keyPath, function() {
-          utils.removeEmptyDirectories(fs, bucketPath, function() {
+      err => {
+        if (err) return done(err);
+        fs.rmdir(keyPath, () => {
+          utils.removeEmptyDirectories(fs, bucketPath, () => {
             return done();
           });
         });
       }
     );
-  };
+  }
 
-  const getObjectExists = function(bucket, key, done) {
-    const keyPath = path.resolve(getBucketPath(bucket.name), key);
-    fs.stat(keyPath, function(err, file) {
-      if (err || !file.isDirectory()) {
-        return done("Object not found for " + keyPath);
-      }
-      return done(null);
-    });
-  };
-
-  const concatStreams = function(passThrough, streams) {
-    const stream = streams.shift();
-    if (!stream) {
-      passThrough.end();
-      return passThrough;
-    }
-    stream.once("end", function() {
-      concatStreams(passThrough, streams);
-    });
-    stream.pipe(passThrough, { end: false });
-    return passThrough;
-  };
-
-  const combineObjectParts = function(bucket, key, uploadId, parts, req, done) {
-    const sortedParts = _.sortBy(parts, function(part) {
-      return part.number;
-    });
-    const partPaths = _.map(sortedParts, function(part) {
-      return path.resolve(
-        getBucketPath(bucket.name),
+  combineObjectParts(bucket, key, uploadId, parts, req, done) {
+    const sortedParts = sortBy(parts, part => part.number);
+    const partPaths = sortedParts.map(part => {
+      return path.join(
+        this.getBucketPath(bucket.name),
         uploadId + "_" + part.number
       );
     });
-    const partStreams = _.map(partPaths, function(partPath) {
-      return fs.createReadStream(path.join(partPath, CONTENT_FILE));
-    });
-    const combinedPartsStream = concatStreams(new PassThrough(), partStreams);
+    const partStreams = partPaths.map(partPath =>
+      fs.createReadStream(path.join(partPath, CONTENT_FILE))
+    );
+    const combinedPartsStream = this.concatStreams(
+      new PassThrough(),
+      partStreams
+    );
     const keyName = path.join(bucket.name, key);
-    const dirName = path.join(rootDirectory, keyName);
+    const dirName = path.join(this.rootDirectory, keyName);
     fs.mkdirpSync(dirName);
     const contentFile = path.join(dirName, CONTENT_FILE);
     const metaFile = path.join(dirName, METADATA_FILE);
     const writeStream = combinedPartsStream.pipe(
       fs.createWriteStream(contentFile)
     );
-    writeStream.on("error", function(err) {
-      return done(err);
-    });
-    writeStream.on("close", function() {
+    writeStream.on("error", done);
+    writeStream.on("close", () => {
       writeStream.end();
-      _.forEach(partPaths, function(partPath) {
-        fs.removeSync(partPath);
-      });
-      createMetaData(
+      partPaths.forEach(partPath => fs.removeSync(partPath));
+      this.createMetaData(
         {
-          contentFile: contentFile,
+          key,
+          contentFile,
+          metaFile,
           type: req.headers["content-type"],
           encoding: req.headers["content-encoding"],
           disposition: req.headers["content-disposition"],
-          key: key,
-          metaFile: metaFile,
           headers: req.headers
         },
-        function(err, metaData) {
-          if (err) {
-            return done(err);
-          }
-          return done(null, new S3Object(metaData));
+        (err, metaData) => {
+          if (err) return done(err);
+          done(null, new S3Object(metaData));
         }
       );
     });
-  };
+  }
+}
 
-  return {
-    getBuckets: getBuckets,
-    getBucket: getBucket,
-    putBucket: putBucket,
-    deleteBucket: deleteBucket,
-    getObjects: getObjects,
-    getObject: getObject,
-    putObject: putObject,
-    copyObject: copyObject,
-    getObjectExists: getObjectExists,
-    deleteObject: deleteObject,
-    combineObjectParts: combineObjectParts
-  };
-};
 module.exports = FileStore;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,69 +1,71 @@
 "use strict";
 
 const async = require("async");
-const _ = require("lodash");
 const fs = require("fs-extra");
+const { defaults } = require("lodash");
+const https = require("https");
 const os = require("os");
 const path = require("path");
-const https = require("https");
 
 const App = require("./app");
 
-const S3rver = function(options) {
-  this.options = _.defaults({}, options, S3rver.defaultOptions);
-};
+class S3rver {
+  constructor(options) {
+    this.options = defaults({}, options, S3rver.defaultOptions);
+  }
 
-S3rver.prototype.resetFs = function(callback) {
-  const { directory } = this.options;
-  fs.readdir(directory, function(err, buckets) {
-    if (err) return callback(err);
-    async.eachSeries(
-      buckets,
-      function(bucket, callback) {
-        fs.remove(path.join(directory, bucket), callback);
-      },
-      callback
-    );
-  });
-};
-
-S3rver.prototype.getMiddleware = S3rver.prototype.callback = function() {
-  return new App(this.options);
-};
-
-S3rver.prototype.run = function(done) {
-  const app = new App(this.options);
-  let server =
-    (this.options.key && this.options.cert) || this.options.pfx
-      ? https.createServer(this.options, app)
-      : app;
-  server = server
-    .listen(this.options.port, this.options.hostname, err => {
-      done(
-        err,
-        this.options.hostname,
-        this.options.port,
-        this.options.directory
+  resetFs(callback) {
+    const { directory } = this.options;
+    fs.readdir(directory, (err, buckets) => {
+      if (err) return callback(err);
+      async.eachSeries(
+        buckets,
+        (bucket, callback) => {
+          fs.remove(path.join(directory, bucket), callback);
+        },
+        callback
       );
-    })
-    .on("error", err => {
-      done(err);
     });
-  server.close = callback => {
-    const { close } = Object.getPrototypeOf(server);
-    return close.call(server, () => {
-      app.logger.unhandleExceptions();
-      app.logger.close();
-      if (this.options.removeBucketsOnClose) {
-        this.resetFs(callback);
-      } else {
-        callback();
-      }
-    });
-  };
-  server.s3Event = app.s3Event;
-  return server;
-};
+  }
+
+  callback() {
+    return new App(this.options);
+  }
+
+  run(done) {
+    const app = new App(this.options);
+    let server =
+      (this.options.key && this.options.cert) || this.options.pfx
+        ? https.createServer(this.options, app)
+        : app;
+    server = server
+      .listen(this.options.port, this.options.hostname, err => {
+        done(
+          err,
+          this.options.hostname,
+          this.options.port,
+          this.options.directory
+        );
+      })
+      .on("error", err => {
+        done(err);
+      });
+    server.close = callback => {
+      const { close } = Object.getPrototypeOf(server);
+      return close.call(server, () => {
+        app.logger.unhandleExceptions();
+        app.logger.close();
+        if (this.options.removeBucketsOnClose) {
+          this.resetFs(callback);
+        } else {
+          callback();
+        }
+      });
+    };
+    server.s3Event = app.s3Event;
+    return server;
+  }
+}
 
 S3rver.defaultOptions = {
   port: 4578,
@@ -75,5 +77,6 @@ S3rver.defaultOptions = {
   errorDocument: "",
   removeBucketsOnClose: false
 };
+S3rver.prototype.getMiddleware = S3rver.prototype.callback;
 
 module.exports = S3rver;

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -1,8 +1,9 @@
-"use strict";
-const Bucket = function(name, creationDate) {
-  return {
-    name: name,
-    creationDate: creationDate
-  };
-};
+'use strict';
+
+class Bucket {
+  constructor(name, creationDate) {
+    this.name = name;
+    this.creationDate = creationDate;
+  }
+}
 module.exports = Bucket;

--- a/lib/models/s3-event.js
+++ b/lib/models/s3-event.js
@@ -1,74 +1,75 @@
 'use strict';
 const crypto = require('crypto');
 
-const S3Event = function (eventData, reqParams) {
-  const {reqHeaders,sourceIp} = reqParams;
-  let eventName = '';
-  const s3Object = {
-    "key": eventData.S3Item.key,
-    "sequencer": Date.now().toString(16).toUpperCase()
-  };
-  switch (eventData.eventType) {
-    case 'Copy':
-      eventName = 'ObjectCreated:Copy';
-      s3Object.size = eventData.S3Item.size;
-      break;
-
-    case 'Put':
-      eventName = 'ObjectCreated:Put';
-      s3Object.size = eventData.S3Item.size;
-      s3Object.eTag = eventData.S3Item.md5;
-      break;
-
-    case 'Post':
-      eventName = 'ObjectCreated:Post';
-      s3Object.size = eventData.S3Item.size;
-      s3Object.eTag = eventData.S3Item.md5;
-      break;
-
-    case 'Delete':
-      eventName = 'ObjectRemoved:Delete';
-      break;
-  }
-
-  const event = {
-    "Records": [
-      {
-        "eventVersion": "2.0",
-        "eventSource": "aws:s3",
-        "awsRegion": "us-east-1",
-        "eventTime": eventData.S3Item.creationDate || new Date().toISOString(),
-        "eventName": eventName,
-        "userIdentity": {
-          "principalId": 'AWS:' + randomString(21).toUpperCase(),
-        },
-        "requestParameters": {
-          "sourceIPAddress": sourceIp
-        },
-        "responseElements": {
-          "x-amz-request-id": randomString(16).toUpperCase(),
-          "x-amz-id-2": crypto.createHash('sha256').update(reqHeaders.host).digest('base64')
-        },
-        "s3": {
-          "s3SchemaVersion": "1.0",
-          "configurationId": "testConfigId",
-          "bucket": {
-            "name": eventData.bucket,
-            "ownerIdentity": {
-              "principalId": randomString(14).toUpperCase()
-            },
-            "arn": "arn:aws:s3: : :" + eventData.bucket
-          },
-          "object": s3Object
-        }
-      }
-    ]
-  }
-  return event;
-};
-
-const randomString = function (length) {
-  return crypto.randomBytes(32).toString("hex").slice(0,length);
+function randomString(length) {
+  return crypto.randomBytes(32).toString("hex").slice(0, length);
 }
+
+class S3Event {
+  constructor(eventData, reqParams) {
+    const { reqHeaders,sourceIp } = reqParams;
+    let eventName = '';
+    const s3Object = {
+      "key": eventData.S3Item.key,
+      "sequencer": Date.now().toString(16).toUpperCase()
+    };
+    switch (eventData.eventType) {
+      case 'Copy':
+        eventName = 'ObjectCreated:Copy';
+        s3Object.size = eventData.S3Item.size;
+        break;
+
+      case 'Put':
+        eventName = 'ObjectCreated:Put';
+        s3Object.size = eventData.S3Item.size;
+        s3Object.eTag = eventData.S3Item.md5;
+        break;
+
+      case 'Post':
+        eventName = 'ObjectCreated:Post';
+        s3Object.size = eventData.S3Item.size;
+        s3Object.eTag = eventData.S3Item.md5;
+        break;
+
+      case 'Delete':
+        eventName = 'ObjectRemoved:Delete';
+        break;
+    }
+
+    return {
+      "Records": [
+        {
+          "eventVersion": "2.0",
+          "eventSource": "aws:s3",
+          "awsRegion": "us-east-1",
+          "eventTime": eventData.S3Item.creationDate || new Date().toISOString(),
+          "eventName": eventName,
+          "userIdentity": {
+            "principalId": 'AWS:' + randomString(21).toUpperCase(),
+          },
+          "requestParameters": {
+            "sourceIPAddress": sourceIp
+          },
+          "responseElements": {
+            "x-amz-request-id": randomString(16).toUpperCase(),
+            "x-amz-id-2": crypto.createHash('sha256').update(reqHeaders.host).digest('base64')
+          },
+          "s3": {
+            "s3SchemaVersion": "1.0",
+            "configurationId": "testConfigId",
+            "bucket": {
+              "name": eventData.bucket,
+              "ownerIdentity": {
+                "principalId": randomString(14).toUpperCase()
+              },
+              "arn": "arn:aws:s3: : :" + eventData.bucket
+            },
+            "object": s3Object
+          }
+        }
+      ]
+    };
+  }
+};
 
 module.exports = S3Event;

--- a/lib/models/s3-object.js
+++ b/lib/models/s3-object.js
@@ -1,16 +1,20 @@
-"use strict";
-const S3Object = function(s3Item) {
-  const item = {
-    key: s3Item.key,
-    contentType: s3Item.contentType,
-    contentEncoding: s3Item.contentEncoding,
-    contentDisposition: s3Item.contentDisposition,
-    md5: s3Item.md5,
-    size: s3Item.size,
-    modifiedDate: s3Item.modifiedDate,
-    creationDate: s3Item.creationDate,
-    customMetaData: s3Item.customMetaData
-  };
-  return item;
-};
+'use strict';
+
+const { pick } = require('lodash');
+
+class S3Object {
+  constructor(s3Item) {
+    Object.assign(this, pick(s3Item, [
+      'key',
+      'contentType',
+      'contentEncoding',
+      'contentDisposition',
+      'md5',
+      'size',
+      'modifiedDate',
+      'creationDate',
+      'customMetaData'
+    ]));
+  }
+}
 module.exports = S3Object;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,8 @@
 "use strict";
-const path = require("path");
+
 const async = require("async");
 const fs = require("fs-extra");
+const path = require("path");
 
 // Gathered from http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
 exports.walk = function(dir) {
@@ -23,25 +24,21 @@ exports.walk = function(dir) {
 };
 
 // Walk a directory and remove every folder that is empty inside it
-function removeEmptyDirectories(fs, directory, callback) {
-  fs.stat(directory, function(err, stat) {
-    if (err) return callback(err);
-    if (!stat.isDirectory()) return callback();
-    fs.readdir(directory, function(err, list) {
-      if (err) return callback(err);
-      if (list.length === 0) {
-        return fs.rmdir(directory, callback);
-      }
+exports.removeEmptyDirectories = function(fs, directory, done) {
+  fs.stat(directory, (err, stat) => {
+    if (err) return done(err);
+    if (!stat.isDirectory()) return done();
+    fs.readdir(directory, (err, list) => {
+      if (err) return done(err);
+      if (!list.length) return fs.rmdir(directory, done);
       async.eachSeries(
         list,
-        function(item, callback) {
+        (item, callback) => {
           const filename = path.join(directory, item);
-          removeEmptyDirectories(fs, filename, callback);
+          exports.removeEmptyDirectories(fs, filename, callback);
         },
-        callback
+        done
       );
     });
   });
-}
-
-exports.removeEmptyDirectories = removeEmptyDirectories;
+};

--- a/lib/xml-template-builder.js
+++ b/lib/xml-template-builder.js
@@ -1,17 +1,51 @@
 "use strict";
 
 const jstoxml = require("jstoxml");
-const _ = require("lodash");
 
-const xml = function() {
-  const DISPLAY_NAME = "S3rver";
-  const buildQueryContentXML = function(data, options) {
-    let content = _.map(data.objects, function(item) {
-      return {
+const DISPLAY_NAME = "S3rver";
+
+exports.buildBuckets = function(buckets) {
+  return jstoxml.toXML(
+    {
+      _name: "ListAllMyBucketsResult",
+      _attrs: { xmlns: "http://doc.s3.amazonaws.com/2006-03-01" },
+      _content: {
+        Owner: {
+          ID: 123,
+          DisplayName: DISPLAY_NAME
+        },
+        Buckets: buckets.map(bucket => ({
+          Bucket: {
+            Name: bucket.name,
+            CreationDate: bucket.creationDate.toISOString()
+          }
+        }))
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildBucketQuery = function(options, data) {
+  const xml = {
+    _name: "ListBucketResult",
+    _attrs: { xmlns: "http://doc.s3.amazonaws.com/2006-03-01" },
+    _content: [
+      {
+        Name: options.bucketName,
+        Prefix: options.prefix || "",
+        Marker: options.marker || "",
+        MaxKeys: options.maxKeys,
+        IsTruncated: false
+      },
+      ...data.objects.map(item => ({
         Contents: {
           Key: item.key,
           LastModified: item.modifiedDate,
-          ETag: '"' + item.md5 + '"',
+          ETag: JSON.stringify(item.md5),
           Size: item.size,
           StorageClass: "Standard",
           Owner: {
@@ -19,218 +53,182 @@ const xml = function() {
             DisplayName: DISPLAY_NAME
           }
         }
-      };
-    });
-    content = content.concat(
-      _.map(data.commonPrefixes, function(prefix) {
-        return {
-          CommonPrefixes: { Prefix: prefix }
-        };
-      })
-    );
-    content.unshift({
-      Name: options.bucketName,
-      Prefix: options.prefix || "",
-      Marker: options.marker || "",
-      MaxKeys: options.maxKeys,
-      IsTruncated: false
-    });
-    return content;
+      })),
+      ...data.commonPrefixes.map(prefix => ({
+        CommonPrefixes: { Prefix: prefix }
+      }))
+    ]
   };
-  return {
-    buildBuckets: function(buckets) {
-      return jstoxml.toXML(
-        {
-          _name: "ListAllMyBucketsResult",
-          _attrs: { xmlns: "http://doc.s3.amazonaws.com/2006-03-01" },
-          _content: {
-            Owner: {
-              ID: 123,
-              DisplayName: DISPLAY_NAME
-            },
-            Buckets: _.map(buckets, function(bucket) {
-              return {
-                Bucket: {
-                  Name: bucket.name,
-                  CreationDate: bucket.creationDate.toISOString()
-                }
-              };
-            })
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildBucketQuery: function(options, data) {
-      const xml = {
-        _name: "ListBucketResult",
-        _attrs: { xmlns: "http://doc.s3.amazonaws.com/2006-03-01" },
-        _content: buildQueryContentXML(data, options)
-      };
-      return jstoxml.toXML(xml, {
-        header: true,
-        indent: "  "
-      });
-    },
-    buildBucketNotFound: function(bucketName) {
-      return jstoxml.toXML(
-        {
-          Error: {
-            Code: "NoSuchBucket",
-            Message: "The specified bucket does not exist",
-            Resource: bucketName,
-            RequestId: 1
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildBucketNotEmpty: function(bucketName) {
-      return jstoxml.toXML(
-        {
-          Error: {
-            Code: "BucketNotEmpty",
-            Message: "The bucket your tried to delete is not empty",
-            Resource: bucketName,
-            RequestId: 1,
-            HostId: 2
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildKeyNotFound: function(key) {
-      return jstoxml.toXML(
-        {
-          Error: {
-            Code: "NoSuchKey",
-            Message: "The specified key does not exist",
-            Resource: key,
-            RequestId: 1
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildObjectsDeleted: function(keys) {
-      return jstoxml.toXML(
-        {
-          _name: "DeleteResult",
-          _attrs: { xmlns: "http://s3.amazonaws.com/doc/2006-03-01/" },
-          _content: keys.map(function(k) {
-            return { Deleted: { Key: k } };
-          })
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildError: function(code, message) {
-      return jstoxml.toXML(
-        {
-          Error: {
-            Code: code,
-            Message: message,
-            RequestId: 1
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildAcl: function() {
-      return jstoxml.toXML(
-        {
-          _name: "AccessControlPolicy",
-          _attrs: { xmlns: "http://doc.s3.amazonaws.com/2006-03-01" },
-          _content: {
-            Owner: {
-              ID: 123,
-              DisplayName: DISPLAY_NAME
-            },
-            AccessControlList: {
-              Grant: {
-                _name: "Grantee",
-                _attrs: {
-                  "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-                  "xsi:type": "CanonicalUser"
-                },
-                _content: {
-                  ID: "abc",
-                  DisplayName: "You"
-                }
-              },
-              Permission: "FULL_CONTROL"
-            }
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildCopyObject: function(item) {
-      return jstoxml.toXML(
-        {
-          CopyObjectResult: {
-            LastModified: new Date(item.modifiedDate).toISOString(),
-            ETag: '"' + item.md5 + '"'
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildInitiateMultipartUploadResult: function(bucket, key, uploadId) {
-      return jstoxml.toXML(
-        {
-          InitiateMultipartUploadResult: {
-            Bucket: bucket,
-            Key: key,
-            UploadId: uploadId
-          }
-        },
-        {
-          header: true,
-          indent: "  "
-        }
-      );
-    },
-    buildCompleteMultipartUploadResult: function(bucket, key, location, item) {
-      return jstoxml.toXML(
-        {
-          CompleteMultipartUploadResult: {
-            Location: location,
-            Bucket: bucket,
-            Key: key,
-            ETag: '"' + item.md5 + '"'
-          }
-        },
-        {
-          header: true,
-          indent: " "
-        }
-      );
-    }
-  };
+  return jstoxml.toXML(xml, {
+    header: true,
+    indent: "  "
+  });
 };
-module.exports = xml();
+
+exports.buildBucketNotFound = function(bucketName) {
+  return jstoxml.toXML(
+    {
+      Error: {
+        Code: "NoSuchBucket",
+        Message: "The specified bucket does not exist",
+        Resource: bucketName,
+        RequestId: 1
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildBucketNotEmpty = function(bucketName) {
+  return jstoxml.toXML(
+    {
+      Error: {
+        Code: "BucketNotEmpty",
+        Message: "The bucket your tried to delete is not empty",
+        Resource: bucketName,
+        RequestId: 1,
+        HostId: 2
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildKeyNotFound = function(key) {
+  return jstoxml.toXML(
+    {
+      Error: {
+        Code: "NoSuchKey",
+        Message: "The specified key does not exist",
+        Resource: key,
+        RequestId: 1
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildObjectsDeleted = function(keys) {
+  return jstoxml.toXML(
+    {
+      _name: "DeleteResult",
+      _attrs: { xmlns: "http://s3.amazonaws.com/doc/2006-03-01/" },
+      _content: keys.map(k => ({ Deleted: { Key: k } }))
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildError = function(code, message) {
+  return jstoxml.toXML(
+    {
+      Error: {
+        Code: code,
+        Message: message,
+        RequestId: 1
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildAcl = function() {
+  return jstoxml.toXML(
+    {
+      _name: "AccessControlPolicy",
+      _attrs: { xmlns: "http://doc.s3.amazonaws.com/2006-03-01" },
+      _content: {
+        Owner: {
+          ID: 123,
+          DisplayName: DISPLAY_NAME
+        },
+        AccessControlList: {
+          Grant: {
+            _name: "Grantee",
+            _attrs: {
+              "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+              "xsi:type": "CanonicalUser"
+            },
+            _content: {
+              ID: "abc",
+              DisplayName: "You"
+            }
+          },
+          Permission: "FULL_CONTROL"
+        }
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildCopyObject = function(item) {
+  return jstoxml.toXML(
+    {
+      CopyObjectResult: {
+        LastModified: new Date(item.modifiedDate).toISOString(),
+        ETag: JSON.stringify(item.md5)
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildInitiateMultipartUploadResult = function(bucket, key, uploadId) {
+  return jstoxml.toXML(
+    {
+      InitiateMultipartUploadResult: {
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId
+      }
+    },
+    {
+      header: true,
+      indent: "  "
+    }
+  );
+};
+
+exports.buildCompleteMultipartUploadResult = function(
+  bucket,
+  key,
+  location,
+  item
+) {
+  return jstoxml.toXML(
+    {
+      CompleteMultipartUploadResult: {
+        Location: location,
+        Bucket: bucket,
+        Key: key,
+        ETag: JSON.stringify(item.md5)
+      }
+    },
+    {
+      header: true,
+      indent: " "
+    }
+  );
+};


### PR DESCRIPTION
- Use classes where applicable
- Use arrow functions for callbacks
- Use object initializer shorthands
- Swap lodash functions with native implementations where possible
- Alphabetically order imported modules

I avoided making everything use Promises since I'd rather jump straight to async/await style when we eventually decide to do that.

This shouldn't change any existing behavior at all, it should all be purely syntax updates.