### PR TITLE
Fix OPTIONS requests when Access-Control-Request-Headers header is present

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -83,13 +83,15 @@ module.exports = function cors(config) {
         return res.status(403).send(template);
       }
 
-      const requestHeaders = req.get("access-control-request-headers") || [];
+      const requestHeaders = (
+        req.get("access-control-request-headers") || ""
+      ).split(",");
       const allowedHeaders = matchedRule
         ? requestHeaders
+            .map(header => header.trim().toLowerCase())
             .filter(header =>
               matchedRule.AllowedHeader.some(pattern => pattern.test(header))
             )
-            .map(header => header.toLowerCase())
         : [];
 
       if (!matchedRule || allowedHeaders.length < requestHeaders.length) {


### PR DESCRIPTION
I accidentally treated the result of `req.get()` as an array and didn't split it by commas. I've added test cases for `OPTIONS` requests and adjusted the implementation accordingly.