### PR TITLE
Fix CORS middleware when no config is specified

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -45,12 +45,15 @@ module.exports = function cors(config) {
   return function(req, res, next) {
     // Prefer the Access-Control-Request-Method header if supplied
     const method = req.get("access-control-request-method") || req.method;
-    const matchedRule = CORSConfiguration.CORSRule.find(rule => {
-      return (
-        rule.AllowedOrigin.some(pattern => pattern.test(req.get("origin"))) &&
-        includes(rule.AllowedMethod, method)
-      );
-    });
+    const matchedRule = CORSConfiguration
+      ? CORSConfiguration.CORSRule.find(rule => {
+          return (
+            rule.AllowedOrigin.some(pattern =>
+              pattern.test(req.get("origin"))
+            ) && includes(rule.AllowedMethod, method)
+          );
+        })
+      : null;
 
     if (req.method === "OPTIONS") {
       let template;

--- a/test/test.js
+++ b/test/test.js
@@ -1523,6 +1523,38 @@ describe("S3rver CORS Policy Tests", function() {
       );
     });
   });
+
+  it("should respond to OPTIONS requests with a Forbidden response when CORS is disabled", function(done) {
+    const origin = "http://foo.bar.com";
+    const params = { Bucket: bucket, Key: "image" };
+    const url = s3Client.getSignedUrl("getObject", params);
+    const s3rver = new S3rver({
+      port: 4569,
+      hostname: "localhost",
+      silent: true,
+      cors: false
+    }).run(err => {
+      if (err) return done(err);
+
+      request(
+        {
+          method: "OPTIONS",
+          url,
+          headers: {
+            origin,
+            "Access-Control-Request-Method": "GET"
+          }
+        },
+        (err, response) => {
+          s3rver.close(() => {
+            if (err) return done(err);
+            response.statusCode.should.equal(403);
+            done();
+          });
+        }
+      );
+    });
+  });
 });
 
 describe("S3rver Tests with Static Web Hosting", function() {


### PR DESCRIPTION
Another minor mistake I didn't catch as I was trying to tidy up this feature. Originally I had `matchedRule`
in a different spot where it `CORSConfiguration` was assumed to be defined but it got moved around when I implemented `OPTIONS` request handling.