### PR TITLE
Support running on port 0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ class S3rver {
         done(
           err,
           this.options.hostname,
-          this.options.port,
+          server.address().port,
           this.options.directory
         );
       })

--- a/test/test.js
+++ b/test/test.js
@@ -1605,6 +1605,17 @@ describe("S3rver Class Tests", function() {
     s3rver.options.cert.should.be.an.instanceOf(Buffer);
     s3rver.options.should.have.property("removeBucketsOnClose", true);
   });
+  it("should support running on port 0", function(done) {
+    const s3rver = new S3rver({
+      port: 0,
+      hostname: "localhost",
+      silent: true
+    }).run((err, hostname, port) => {
+      if (err) return done(err);
+      should(port).be.above(0);
+      s3rver.close(done);
+    });
+  });
 });
 
 describe("Data directory cleanup", function() {


### PR DESCRIPTION
When the user passes `port : 0`, the operating system will dynamically allocate an available port for us, which we then return to the user so that they know how to connect to us.

Fixes #162