### PR TITLE
Marker should be a prefix, not a full match

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -232,7 +232,7 @@ class FileStore {
       let startAt = 0;
       let found = false;
       filteredKeys.forEach((key, index) => {
-        if (options.marker == key.replace(bucketPath + "/", "")) {
+        if (key.replace(bucketPath + "/", "").startsWith(options.marker)) {
           startAt = index + 1;
           found = true;
         }

--- a/test/test.js
+++ b/test/test.js
@@ -902,7 +902,7 @@ describe("S3rver Tests", function() {
     const testObjects = [
       "akey1",
       "akey2",
-      "akey3",
+      "akey32",
       "key/key1",
       "key1",
       "key2",


### PR DESCRIPTION
Our s3 production works this way so I guess this code hasn't been updated or has always been false.
I would love a patch release for this <3