### PR TITLE
Test objects stored with no content type

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -194,6 +194,27 @@ describe("S3rver Tests", function() {
     });
   });
 
+  it("should store a text object with no content type and retrieve it", function(done) {
+    request(
+      {
+        method: "PUT",
+        baseUrl: s3Client.config.endpoint,
+        url: `/${buckets[0]}/text`,
+        body: "Hello!"
+      },
+      (err, res) => {
+        if (err) return done(err);
+        should(res.statusCode).equal(200);
+        const params = { Bucket: buckets[0], Key: "text" };
+        s3Client.getObject(params, (err, data) => {
+          if (err) return done(err);
+          should(data.ContentType).equal("binary/octet-stream");
+          done();
+        });
+      }
+    );
+  });
+
   it("should trigger a Put event", function(done) {
     const params = { Bucket: buckets[0], Key: "testPutKey", Body: "Hello!" };
     const putSubs = s3rver.s3Event.subscribe(event => {


### PR DESCRIPTION
Closes #154. I had to use `request` instead of an `AWS.S3` client since it always forces the `application/octet-stream` content type if none is specified.