### PR TITLE
Include correct IsTruncated value in listObjects response

### DIFF
--- a/lib/xml-template-builder.js
+++ b/lib/xml-template-builder.js
@@ -35,7 +35,7 @@ exports.buildBucketQuery = function(options, data) {
     _attrs: { xmlns: "http://doc.s3.amazonaws.com/2006-03-01" },
     _content: [
       {
-        IsTruncated: options.isTruncated || false,
+        IsTruncated: data.isTruncated || false,
         Marker: options.marker || "",
         Name: options.bucketName,
         Prefix: options.prefix || "",

--- a/test/test.js
+++ b/test/test.js
@@ -726,6 +726,7 @@ describe("S3rver Tests", function() {
     );
     const data = yield s3Client.listObjects({ Bucket: buckets[1] }).promise();
     expect(data.Contents).to.have.lengthOf(testObjects.length);
+    expect(data.IsTruncated).to.be.false;
   });
 
   it("should list objects in a bucket filtered by a prefix", function*() {
@@ -912,18 +913,18 @@ describe("S3rver Tests", function() {
 
   it("should return one thousand small objects", function*() {
     yield generateTestObjects(s3Client, buckets[2], 2000);
-    const objects = yield s3Client
-      .listObjects({ Bucket: buckets[2] })
-      .promise();
-    expect(objects.Contents).to.have.lengthOf(1000);
+    const data = yield s3Client.listObjects({ Bucket: buckets[2] }).promise();
+    expect(data.IsTruncated).to.be.true;
+    expect(data.Contents).to.have.lengthOf(1000);
   });
 
   it("should return 500 small objects", function*() {
     yield generateTestObjects(s3Client, buckets[2], 1000);
-    const objects = yield s3Client
+    const data = yield s3Client
       .listObjects({ Bucket: buckets[2], MaxKeys: 500 })
       .promise();
-    expect(objects.Contents).to.have.lengthOf(500);
+    expect(data.IsTruncated).to.be.true;
+    expect(data.Contents).to.have.lengthOf(500);
   });
 
   it("should delete 500 small objects", function*() {


### PR DESCRIPTION
I never added any tests checking that the value for IsTruncated actually made it into the response. I modified a couple relevant tests to check the flag after fixing the XML response.