### PR TITLE
Decode x-amz-copy-source to support spaces & special characters

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -148,7 +148,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
   }
 
   function copyObject(req, res) {
-    let copySource = req.headers["x-amz-copy-source"];
+    let copySource = decodeURI(req.headers["x-amz-copy-source"]);
     copySource = copySource.startsWith("/") ? copySource.slice(1) : copySource;
     let [srcBucket, ...srcKey] = copySource.split("/");
     srcKey = srcKey.join("/");


### PR DESCRIPTION
To match how S3 copyObject works, this changes s3rver to URI-decode the value passed in the `x-amz-copy-source` header.

[S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys) say UTF-8 is supported and [copyObject reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property) says "CopySource — (String) The name of the source bucket and key name of the source object, separated by a slash (/). *Must be URL-encoded.*"

p.s. s3rver is awesome, thank you for making it!