### PR TITLE
[wip] adjust code for breaking changes in winston@3.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ class S3rver {
     server.close = callback => {
       const { close } = Object.getPrototypeOf(server);
       return close.call(server, () => {
-        app.logger.unhandleExceptions();
+        app.logger.exceptions.unhandle();
         app.logger.close();
         if (this.options.removeBucketsOnClose) {
           this.resetFs(callback);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,16 +3,16 @@
 const winston = require("winston");
 
 module.exports = function(silent) {
-  const logger =  winston.createLogger({
+  const logger = winston.createLogger({
     transports: [
       new winston.transports.Console({
         level: "debug",
-        json: false,
+        json: false
       })
     ],
     exitOnError: false
   });
-  logger.emitErrs = true
+  logger.emitErrs = true;
 
   if (silent) {
     logger.remove(winston.transports.Console);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,20 +3,16 @@
 const winston = require("winston");
 
 module.exports = function(silent) {
-  winston.emitErrs = true;
-  const logger = new winston.Logger({
+  const logger =  winston.createLogger({
     transports: [
       new winston.transports.Console({
         level: "debug",
-        humanReadableUnhandledException: true,
-        handleExceptions: true,
         json: false,
-        colorize: true,
-        label: "S3rver"
       })
     ],
     exitOnError: false
   });
+  logger.emitErrs = true
 
   if (silent) {
     logger.remove(winston.transports.Console);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "morgan": "^1.5.1",
     "promise-limit": "^2.6.0",
     "rxjs": "^5.4.0",
-    "winston": "^2.1.0",
+    "winston": "^3.0.0",
     "xml2js": "^0.4.4",
     "xmlbuilder": "^10.0.0"
   },


### PR DESCRIPTION
The current log output looks like this, since winston@3.0.0 uses json as the default output option, seems like we have to pretty print it to restore the previous functionality.

Also the strings are not correctly formatted.

```
{"level":"info","message":"Created new bucket \"%s\" successfully"}
{"message":"PUT /foobars 200 - - 0.410 ms","level":"info"}
{"level":"info","message":"Stored object \"%s\" in bucket \"%s\" successfully"}
{"message":"PUT /foobars/foo.txt 200 - - 0.904 ms","level":"info"}
{"level":"info","message":"Deleted object \"%s\" in bucket \"%s\""}
{"message":"DELETE /foobars/foo.txt 204 - - 0.820 ms","level":"info"}
{"level":"info","message":"Stored object \"%s\" in bucket \"%s\" successfully"}
{"message":"PUT /foobars/foo2.txt 200 - - 2.294 ms","level":"info"}
```