### PR TITLE
Avoid monkeypatching the close method on the returned server instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const async = require("async");
 const fs = require("fs-extra");
 const { defaults } = require("lodash");
 const https = require("https");
@@ -14,18 +13,12 @@ class S3rver {
     this.options = defaults({}, options, S3rver.defaultOptions);
   }
 
-  resetFs(callback) {
+  resetFs() {
     const { directory } = this.options;
-    fs.readdir(directory, (err, buckets) => {
-      if (err) return callback(err);
-      async.eachSeries(
-        buckets,
-        (bucket, callback) => {
-          fs.remove(path.join(directory, bucket), callback);
-        },
-        callback
-      );
-    });
+    const buckets = fs.readdirSync(directory);
+    for (const bucket of buckets) {
+      fs.removeSync(path.join(directory, bucket));
+    }
   }
 
   callback() {
@@ -47,21 +40,14 @@ class S3rver {
           this.options.directory
         );
       })
-      .on("error", err => {
-        done(err);
-      });
-    server.close = callback => {
-      const { close } = Object.getPrototypeOf(server);
-      return close.call(server, () => {
+      .on("close", () => {
         app.logger.unhandleExceptions();
         app.logger.close();
         if (this.options.removeBucketsOnClose) {
-          this.resetFs(callback);
-        } else {
-          callback();
+          this.resetFs();
         }
-      });
-    };
+      })
+      .on("error", done);
     server.s3Event = app.s3Event;
     return server;
   }


### PR DESCRIPTION
This fixes the close() callback not being optional. I was debating if it was a bad idea to make resetFs() sync, but considering unlinking is a pretty cheap file system operation, I think the only scenarios that would see any impact are testing suites that have many s3rver instances running concurrently while serving many files that need cleaned up?