### PR TITLE
Use RxJS pipeable operators

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -4,7 +4,6 @@ const express = require("express");
 const morgan = require("morgan");
 const path = require("path");
 const { Subject } = require("rxjs");
-require("rxjs/add/operator/filter");
 
 const controllers = require("./controllers");
 const cors = require("./cors");

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   "dependencies": {
     "async": "^2.0.0",
     "commander": "^2.6.0",
-    "concat-stream": "^1.4.7",
+    "concat-stream": "^1.5.2",
     "express": "^4.10.6",
     "fs-extra": "^6.0.0",
     "jstoxml": "^1.0.0",
-    "lodash": "^4.0.0",
+    "lodash": "^4.17.5",
     "morgan": "^1.5.1",
     "promise-limit": "^2.6.0",
-    "rxjs": "^5.4.0",
+    "rxjs": "^5.5.0",
     "winston": "^2.1.0",
     "xml2js": "^0.4.4",
     "xmlbuilder": "^10.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,8 @@ const os = require("os");
 const path = require("path");
 const promiseLimit = require("promise-limit");
 const request = require("request-promise-native");
+const { take } = require("rxjs/operators");
+
 const { thunkToPromise } = require("../lib/utils");
 
 const S3rver = require("..");
@@ -201,7 +203,7 @@ describe("S3rver Tests", function() {
   });
 
   it("should trigger a Put event", function*() {
-    const eventPromise = server.s3Event.take(1).toPromise();
+    const eventPromise = server.s3Event.pipe(take(1)).toPromise();
     const body = "Hello!";
     yield s3Client
       .putObject({ Bucket: buckets[0], Key: "testPutKey", Body: body })
@@ -221,7 +223,7 @@ describe("S3rver Tests", function() {
     yield s3Client
       .putObject({ Bucket: buckets[0], Key: "testPut", Body: body })
       .promise();
-    const eventPromise = server.s3Event.take(1).toPromise();
+    const eventPromise = server.s3Event.pipe(take(1)).toPromise();
     yield s3Client
       .copyObject({
         Bucket: buckets[4],
@@ -247,7 +249,7 @@ describe("S3rver Tests", function() {
         Body: body
       })
       .promise();
-    const eventPromise = server.s3Event.take(1).toPromise();
+    const eventPromise = server.s3Event.pipe(take(1)).toPromise();
     yield s3Client
       .deleteObject({ Bucket: buckets[0], Key: "testDelete" })
       .promise();


### PR DESCRIPTION
This adds compatibility with RxJS 6 for when we decide it's appropriate to update, for now we require RxJS 5.5 to avoid breaking changes. This also addresses the insecure dependency warnings on David.