### PR TITLE
Send date when triggering S3 Event after Post/Put

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -500,7 +500,8 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
             eventType: "Put",
             S3Item: new S3Object(object.bucket, object.key, null, {
               "content-length": size,
-              etag: JSON.stringify(md5)
+              etag: JSON.stringify(md5),
+              date: new Date().toISOString()
             })
           });
           res.header("ETag", JSON.stringify(md5));
@@ -592,7 +593,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
                     req.params.bucket,
                     req.params.key,
                     null,
-                    { etag: JSON.stringify(md5), "content-length": size }
+                    { etag: JSON.stringify(md5), "content-length": size, date: new Date().toISOString() }
                   )
                 });
                 // prettier-ignore

--- a/lib/models/s3-object.js
+++ b/lib/models/s3-object.js
@@ -19,7 +19,8 @@ class S3Object {
       // instrinsic metadata determined when retrieving objects
       "last-modified",
       "etag",
-      "content-length"
+      "content-length",
+      "date"
     ]);
     if (!this.metadata["content-type"]) {
       this.metadata["content-type"] = "binary/octet-stream";


### PR DESCRIPTION
S3 Events that are triggered do not contain a proper eventTime value, because of how the code is set up. They instead have "Invalid Date" objects.

There's a few ways this could probably be fixed, one of which is to actually send a date value when triggering the S3 event from the controller after Put/Post object.

Also, "date" wasn't even a proper metadata key within s3-object, so I've added that.