### PR TITLE
S3Event's eventTime should always be a new date

### DIFF
--- a/lib/models/s3-event.js
+++ b/lib/models/s3-event.js
@@ -47,7 +47,7 @@ class S3Event {
           eventVersion: "2.0",
           eventSource: "aws:s3",
           awsRegion: "us-east-1",
-          eventTime: eventData.S3Item.creationDate || new Date().toISOString(),
+          eventTime: new Date().toISOString(),
           eventName: eventName,
           userIdentity: {
             principalId: "AWS:" + randomString(21).toUpperCase()

--- a/lib/models/s3-object.js
+++ b/lib/models/s3-object.js
@@ -34,10 +34,6 @@ class S3Object {
     return parseInt(this.metadata["content-length"]);
   }
 
-  get creationDate() {
-    return new Date(this.metadata["date"]);
-  }
-
   get lastModifiedDate() {
     return new Date(this.metadata["last-modified"]);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -202,6 +202,18 @@ describe("S3rver Tests", function() {
     expect(data.ContentType).to.equal("binary/octet-stream");
   });
 
+  it("should trigger an event with a valid message structure", function*() {
+    const eventPromise = server.s3Event.pipe(take(1)).toPromise();
+    const body = "Hello!";
+    yield s3Client
+      .putObject({ Bucket: buckets[0], Key: "testPutKey", Body: body })
+      .promise();
+    const event = yield eventPromise;
+    const iso8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+    expect(event.Records[0].eventTime).to.match(iso8601);
+    expect(new Date(event.Records[0].eventTime)).to.not.satisfy(isNaN);
+  });
+
   it("should trigger a Put event", function*() {
     const eventPromise = server.s3Event.pipe(take(1)).toPromise();
     const body = "Hello!";


### PR DESCRIPTION
It should not rely on the object's creation date, especially since that value never exists in S3rver.