### PR TITLE
Generic post method to actually allow uploading files

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -519,7 +519,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
           })
         );
       } else if (
-        req.headers["content-type"].indexOf("multipart/form-data") !== -1
+        (req.headers["content-type"] || req.headers["Content-Type"]).indexOf("multipart/form-data") !== -1
       ) {
         const fields = {
           bucket: req.params.bucket

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -519,7 +519,9 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
           })
         );
       } else if (
-        (req.headers["content-type"] || req.headers["Content-Type"]).indexOf("multipart/form-data") !== -1
+        (req.headers["content-type"] || req.headers["Content-Type"]).indexOf(
+          "multipart/form-data"
+        ) !== -1
       ) {
         const fields = {
           bucket: req.params.bucket

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -7,6 +7,7 @@ const path = require("path");
 const { Readable } = require("stream");
 const url = require("url");
 const xml2js = require("xml2js");
+const multiparty = require("multiparty");
 
 const S3Event = require("./models/s3-event");
 const S3Object = require("./models/s3-object");
@@ -517,6 +518,88 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
             deleteObjects(req, res);
           })
         );
+      } else if (
+        req.headers["content-type"].indexOf("multipart/form-data") !== -1
+      ) {
+        const fields = {
+          bucket: req.params.bucket
+        };
+        const form = new multiparty.Form();
+        let chain = Promise.resolve();
+        let fileWasFound = false;
+
+        form.on("error", err => {
+          res.status(400).send(err);
+        });
+
+        form.on("part", part => {
+          if (!part.filename) {
+            chain = chain.then(() => {
+              return new Promise(resolve => {
+                let string = "";
+                part
+                  .on("data", buf => (string += buf.toString()))
+                  .on("end", () => {
+                    fields[part.name] = string;
+                    resolve();
+                  });
+              });
+            });
+          } else {
+            // 'file' must be the last field in the post (this is how aws requires it)
+            fileWasFound = true;
+            chain = chain.then(() => {
+              if (!fields.bucket) {
+                return res.status(405).send(`
+                  <Error>
+                    <Code>MethodNotAllowed</Code>
+                    <Message>The specified method is not allowed against this resource.</Message>
+                  </Error>
+                `);
+              }
+              if (!fields.key) {
+                return res.status(400).send(`
+                  <Error>
+                    <Code>InvalidArgument</Code>
+                    <Message>Bucket POST must contain a field named 'key'.  If it is specified, please check the order of the fields.</Message>
+                  </Error>
+                `);
+              }
+              store.putObject(
+                {
+                  bucket: fields.bucket,
+                  key: fields.key,
+                  metadata: {
+                    "content-type":
+                      fields["Content-Type"] || fields["content-type"]
+                  },
+                  content: part
+                },
+                (err, md5) => {
+                  res.header("ETag", JSON.stringify(md5));
+                  res.status(204).end();
+                }
+              );
+            });
+          }
+
+          part.on("error", function(err) {
+            res.status(400).send(err);
+          });
+        });
+
+        form.on("close", function() {
+          if (!fileWasFound) {
+            res.status(400).send(`
+              <Error>
+                <Code>InvalidArgument</Code>
+                <Message>POST requires exactly one file upload per request.</Message>
+              </Error>
+            `);
+          }
+        });
+
+        form.parse(req);
       } else {
         notFoundResponse(req, res);
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jstoxml": "^1.0.0",
     "lodash": "^4.17.5",
     "morgan": "^1.5.1",
+    "multiparty": "^4.2.1",
     "promise-limit": "^2.6.0",
     "rxjs": "^6.0.0",
     "winston": "^2.1.0",


### PR DESCRIPTION
This PR adds support for uploading a file directly to the bucket via a multipart form post.

### Overview
The createPresignedPost method is an AWS s3 method which creates a presigned url and fields which can be used for posting an s3 object directly to a private bucket

An example of calling this method:
```
s3.createPresignedPost({
  Bucket: 'my_bucket',
  Conditions: [
    ['starts-with', '$key', ''],
  ],
}, (err, data) => {
  if (err) return reject(err);
  resolve(data);
});
```

which returns something like this:
```
{
  "url": "http://localhost:9000/my_bucket",
  "fields": {
    "bucket": "my_bucket",
    "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
    "X-Amz-Credential": "XXX/us-east-1/s3/aws4_request",
    "X-Amz-Date": "20181030T043058Z",
    "X-Amz-Security-Token": "XXX",
    "Policy": "XXX",
    "X-Amz-Signature": "XXX"
  }
}
```

Normally, you can just use the URL returned in the response in a multipart form and upload the file to the bucket.  Currently, s3rver has no support for this upload method.  This PR adds that support.

