### PR TITLE
Handle the case where the access-control-request-header is not provided

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -86,9 +86,10 @@ module.exports = function cors(config) {
         return res.status(403).send(template);
       }
 
-      const requestHeaders = (
-        req.get("access-control-request-headers") || ""
-      ).split(",");
+      const requestHeaders = (req.get("access-control-request-headers") || "")
+        .split(",")
+        .filter(h => h);
+
       const allowedHeaders = matchedRule
         ? requestHeaders
             .map(header => header.trim().toLowerCase())

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -86,9 +86,9 @@ module.exports = function cors(config) {
         return res.status(403).send(template);
       }
 
-      const requestHeaders = (req.get("access-control-request-headers") || "")
-        .split(",")
-        .filter(h => h);
+      const requestHeaders = req.get("access-control-request-headers")
+        ? req.get("access-control-request-headers").split(",")
+        : [];
 
       const allowedHeaders = matchedRule
         ? requestHeaders

--- a/test/test.js
+++ b/test/test.js
@@ -1322,7 +1322,7 @@ describe("S3rver CORS Policy Tests", function() {
         url,
         headers: {
           origin,
-          "Access-Control-Request-Method": "GET",
+          "Access-Control-Request-Method": "GET"
           // No Access-Control-Request-Headers specified...
         }
       });
@@ -1332,7 +1332,7 @@ describe("S3rver CORS Policy Tests", function() {
       yield thunkToPromise(done => server.close(done));
       expect(error).to.not.exist;
     }
-  })
+  });
 });
 
 describe("S3rver Tests with Static Web Hosting", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1302,6 +1302,37 @@ describe("S3rver CORS Policy Tests", function() {
       expect(error).to.exist;
     }
   });
+
+  it("should respond correctly to OPTIONS requests that dont specify access-control-request-headers", function*() {
+    const origin = "http://a-test.example.com";
+    const params = { Bucket: bucket, Key: "image" };
+    const url = s3Client.getSignedUrl("getObject", params);
+    let server;
+    yield thunkToPromise(done => {
+      server = new S3rver({
+        port: 4569,
+        silent: true,
+        cors: fs.readFileSync("./test/resources/cors_test1.xml")
+      }).run(done);
+    });
+    let error;
+    try {
+      yield request({
+        method: "OPTIONS",
+        url,
+        headers: {
+          origin,
+          "Access-Control-Request-Method": "GET",
+          // No Access-Control-Request-Headers specified...
+        }
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      yield thunkToPromise(done => server.close(done));
+      expect(error).to.not.exist;
+    }
+  })
 });
 
 describe("S3rver Tests with Static Web Hosting", function() {


### PR DESCRIPTION
This fixes issue #346 

So for whatever reason the client I am using, when making an `OPTIONS` request to `s3rver` is not specifying any `Access-Control-Request-Header` headers at all. As a result `s3rver` erroneously responds with a 403 error. S3 proper does not have this same issue for the exact same request.

I have added a test which fails with vanilla master code and passes once I made the corresponding fix.

The issue appears to be [here](https://github.com/jamhall/s3rver/blob/master/lib/cors.js#L90) where if the header is not specified then `requestHeaders` ends up being `[ '' ]` rather than `[]`. Then when we get to the check [here](https://github.com/jamhall/s3rver/blob/master/lib/cors.js#L100) the conditional expression `allowedHeaders.length < requestHeaders.length` fails because `[].length < [ '' ].length === true`.

Therefore my solution is to remove empty elements from the set since that should never happen provided there is a value specified in the header.

# Before
curl:
```sh
$ curl -I -X OPTIONS -H "access-control-request-method: PUT" -H "origin: localhost:8888" "http://localhost:4569/example/abc123"
HTTP/1.1 403 Forbidden
Content-Type: application/xml; charset=utf-8
Content-Length: 344
ETag: W/"158-dYD/owyTT+IOwBQKGAb8GxwXdSU"
Date: Thu, 29 Nov 2018 21:23:53 GMT
Connection: keep-alive
```
s3rver:
```sh
$ node .
now listening on host 0.0.0.0 and port 4569
info: [S3rver] OPTIONS /example/abc123 403 344 - 3.963 ms
```

# After
curl:
```sh
$ curl -I -X OPTIONS -H "access-control-request-method: PUT" -H "origin: localhost:8888" "http://localhost:4569/example/abc123"
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: PUT, POST, DELETE, HEAD, OPTIONS
Vary: Origin, Access-Control-Request-Headers, Access-Control-Request-Method
Date: Thu, 29 Nov 2018 21:25:27 GMT
Connection: keep-alive
Content-Length: 0
```
s3rver:
```sh
$ node .
now listening on host 0.0.0.0 and port 4569
info: [S3rver] OPTIONS /example/abc123 200 - - 1.668 ms
```
