### PR TITLE
Fix range handling for oversized and out of range situations

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -39,7 +39,7 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
           "/" +
           object.size
       );
-      res.header("Content-Length", object.range.end + 1 - object.range.start);
+      res.header("Content-Length", object.range.end - object.range.start);
     }
 
     res.status(status);
@@ -439,6 +439,10 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         if (end) options.end = parseInt(end);
       }
       store.getObject(req.params.bucket, keyName, options, (err, object) => {
+        if (err === "ERANGE") {
+          return res.status(416).end();
+        }
+
         if (!object) {
           if (!indexDocument) return errorResponse(req, res, keyName);
           keyName = path.posix.join(keyName, indexDocument);

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -440,6 +440,8 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
       }
       store.getObject(req.params.bucket, keyName, options, (err, object) => {
         if (err === "ERANGE") {
+          res.header("Content-Range", "bytes */" + object);
+
           return res.status(416).end();
         }
 

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -253,9 +253,18 @@ class FilesystemStore {
         if (err) return done(err.code === "ENOENT" ? null : err);
         const object = new S3Object(bucket, key, content, metadata);
         if (options && (options.start || options.end)) {
+          const bytesRead = content.bytesRead;
+          const totalBytes = metadata["content-length"];
+          if (
+            bytesRead === 0 &&
+            (options && options.start && options.start >= totalBytes)
+          ) {
+            return done("ERANGE");
+          }
+
           object.range = {
             start: options.start || 0,
-            end: options.end || object.size - 1
+            end: options.start || 0 + bytesRead
           };
         }
         return done(null, object);

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -259,7 +259,7 @@ class FilesystemStore {
             bytesRead === 0 &&
             (options && options.start && options.start >= totalBytes)
           ) {
-            return done("ERANGE");
+            return done("ERANGE", totalBytes);
           }
 
           object.range = {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "request-promise-native": "1.0.5"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=6.4.0"
   },
   "bugs": {
     "url": "https://github.com/jamhall/s3rver/issues"

--- a/test/test.js
+++ b/test/test.js
@@ -607,6 +607,7 @@ describe("S3rver Tests", function() {
 
   it("out of bounds range requests should return 416", function*() {
     const file = path.join(__dirname, "resources/image0.jpg");
+    const filesize = fs.statSync(file).size;
     yield s3Client
       .putObject({
         Bucket: buckets[0],
@@ -628,6 +629,10 @@ describe("S3rver Tests", function() {
       });
     } catch (err) {
       expect(err.statusCode).to.equal(416);
+      expect(err.response.headers).to.have.property(
+        "content-range",
+        `bytes */${filesize}`
+      );
     }
   });
 


### PR DESCRIPTION
Range requests were doing a few things wrong:

1) always returning true regardless of whether or not the range was successful.  If the range is completely out of bounds a 416 must be returned
2) returning the requested range as the size and not the actual amount of data returned

This broke things that depend on range requests (notably s3-blob-store & feathers-blob) which we use extensively.  Hoping for a quick merge & tag so we can keep pulling from the real upstream.  

Thanks for a great project!