### PR TITLE
reimplement #373 to work on Windows

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -32,14 +32,9 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
     if (object.range) {
       res.header(
         "Content-Range",
-        "bytes " +
-          object.range.start +
-          "-" +
-          object.range.end +
-          "/" +
-          object.size
+        `bytes ${object.range.start}-${object.range.end}/${object.size}`
       );
-      res.header("Content-Length", object.range.end - object.range.start);
+      res.header("Content-Length", object.range.end + 1 - object.range.start);
     }
 
     res.status(status);
@@ -435,16 +430,10 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
         const [start, end] = req.headers["range"]
           .replace("bytes=", "")
           .split("-");
-        options.start = parseInt(start);
-        if (end) options.end = parseInt(end);
+        options.start = Number(start);
+        if (end) options.end = Number(end);
       }
       store.getObject(req.params.bucket, keyName, options, (err, object) => {
-        if (err === "ERANGE") {
-          res.header("Content-Range", "bytes */" + object);
-
-          return res.status(416).end();
-        }
-
         if (!object) {
           if (!indexDocument) return errorResponse(req, res, keyName);
           keyName = path.posix.join(keyName, indexDocument);
@@ -452,6 +441,12 @@ module.exports = function(rootDirectory, logger, indexDocument, errorDocument) {
             if (!object) return errorResponse(req, res, keyName);
             buildResponse(req, res, 200, object);
           });
+        }
+
+        // Range request was out of range
+        if (object.range && !object.content) {
+          res.header("Content-Range", `bytes */${object.size}`);
+          return res.status(416).end();
         }
 
         const noneMatch = req.headers["if-none-match"];

--- a/lib/models/s3-object.js
+++ b/lib/models/s3-object.js
@@ -31,7 +31,7 @@ class S3Object {
   }
 
   get size() {
-    return parseInt(this.metadata["content-length"]);
+    return Number(this.metadata["content-length"]);
   }
 
   get lastModifiedDate() {

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -239,37 +239,31 @@ class FilesystemStore {
     }
 
     const dirName = path.join(this.getBucketPath(bucket), key);
-    async.parallel(
-      [
-        callback => {
-          const readStream = fs
-            .createReadStream(path.join(dirName, CONTENT_FILE), options)
-            .on("error", callback)
-            .on("open", () => callback(null, readStream));
-        },
-        callback => this.retrieveMetadata(bucket, key, callback)
-      ],
-      (err, [content, metadata] = []) => {
-        if (err) return done(err.code === "ENOENT" ? null : err);
-        const object = new S3Object(bucket, key, content, metadata);
+    this.retrieveMetadata(bucket, key, (err, metadata) => {
+      if (err) return done(err.code === "ENOENT" ? null : err);
+      const lastByte = Number(metadata["content-length"]) - 1;
+      const range = {
+        start: (options && options.start) || 0,
+        end: Math.min((options && options.end) || Infinity, lastByte)
+      };
+      if (range.start < 0 || Math.min(range.end, lastByte) < range.start) {
+        const object = new S3Object(bucket, key, null, metadata);
         if (options && (options.start || options.end)) {
-          const bytesRead = content.bytesRead;
-          const totalBytes = metadata["content-length"];
-          if (
-            bytesRead === 0 &&
-            (options && options.start && options.start >= totalBytes)
-          ) {
-            return done("ERANGE", totalBytes);
-          }
-
-          object.range = {
-            start: options.start || 0,
-            end: options.start || 0 + bytesRead
-          };
+          object.range = range;
         }
         return done(null, object);
       }
-    );
+      const content = fs
+        .createReadStream(path.join(dirName, CONTENT_FILE), range)
+        .on("error", done)
+        .on("open", () => {
+          const object = new S3Object(bucket, key, content, metadata);
+          if (options && (options.start || options.end)) {
+            object.range = range;
+          }
+          return done(null, object);
+        });
+    });
   }
 
   putObject(object, done) {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "request-promise-native": "1.0.5"
   },
   "engines": {
-    "node": ">=6.4.0"
+    "node": ">=6.0.0"
   },
   "bugs": {
     "url": "https://github.com/jamhall/s3rver/issues"

--- a/test/test.js
+++ b/test/test.js
@@ -621,19 +621,22 @@ describe("S3rver Tests", function() {
       Key: "image"
     });
 
+    let error;
     try {
       yield request({
         url,
-        headers: { range: "bytes=65536-66000" },
+        headers: { range: `bytes=${filesize + 100}-${filesize + 200}` },
         resolveWithFullResponse: true
       });
     } catch (err) {
-      expect(err.statusCode).to.equal(416);
-      expect(err.response.headers).to.have.property(
-        "content-range",
-        `bytes */${filesize}`
-      );
+      error = err;
     }
+    expect(error).to.exist;
+    expect(error.statusCode).to.equal(416);
+    expect(error.response.headers).to.have.property(
+      "content-range",
+      `bytes */${filesize}`
+    );
   });
 
   it("partial out of bounds range requests should return actual length of returned data", function*() {


### PR DESCRIPTION
This ensures no file handles are left open after receiving an unsatisfiable range request by never opening the stream in the first place.

Also I found that on my end, the value reported  by `fs.ReadStream#byteRead` was often 0 bytes since I'm guessing that value only reflects what has been lazily read.