### PR TITLE
Fix empty directory cleanup when deleting a deeply nested key

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -352,7 +352,7 @@ class FilesystemStore {
         if (err && err.code !== "ENOENT") return done(err);
 
         fs.rmdir(keyPath, () => {
-          utils.removeEmptyDirectories(fs, bucketPath, () => done());
+          utils.clearEmptyDirectoryTree(bucketPath, () => done());
         });
       }
     );

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,35 +20,36 @@ exports.walk = function(dir) {
   return results;
 };
 
-function removeEmptyDirectories(fs, directories, done) {
-  async.eachSeries(
-    directories,
-    (directory, callback) => {
-      fs.stat(directory, (err, stat) => {
+function removeEmptyDirectoryTree(directory, callback) {
+  fs.readdir(directory, (err, list) => {
+    if (err)
+      return callback(err.code !== "ENOTDIR" && err.code !== "ENOENT" && err);
+    async.eachSeries(
+      list.map(item => path.join(directory, item)),
+      removeEmptyDirectoryTree,
+      err => {
         if (err) return callback(err);
-        if (!stat.isDirectory()) return callback();
+        // check if the current directory is empty now
         fs.readdir(directory, (err, list) => {
-          if (err) return callback(err);
-          if (!list.length) return fs.rmdir(directory, callback);
-          removeEmptyDirectories(
-            fs,
-            list.map(item => path.join(directory, item)),
-            callback
-          );
+          if (err)
+            return callback(
+              err.code !== "ENOTDIR" && err.code !== "ENOENT" && err
+            );
+          if (list.length) return callback();
+          return fs.rmdir(directory, callback);
         });
-      });
-    },
-    done
-  );
+      }
+    );
+  });
 }
 
 // Walk a directory and remove every folder that is empty inside it (but not it itself)
-exports.removeEmptyDirectories = function(fs, directory, done) {
+exports.clearEmptyDirectoryTree = function(directory, done) {
   fs.readdir(directory, (err, list) => {
     if (err) return done(err);
-    removeEmptyDirectories(
-      fs,
+    async.eachSeries(
       list.map(item => path.join(directory, item)),
+      removeEmptyDirectoryTree,
       done
     );
   });

--- a/test/test.js
+++ b/test/test.js
@@ -1623,7 +1623,7 @@ describe("Data directory cleanup", function() {
     }
   });
 
-  it("Can delete a bucket that is empty after some key that includes a directory has been deleted", function*() {
+  it("Can delete a bucket that is empty after some key nested in a directory has been deleted", function*() {
     const bucket = "foobars";
 
     let server;
@@ -1643,20 +1643,18 @@ describe("Data directory cleanup", function() {
     try {
       yield s3Client.createBucket({ Bucket: bucket }).promise();
       yield s3Client
-        .putObject({ Bucket: bucket, Key: "foo/foo.txt", Body: "Hello!" })
+        .putObject({ Bucket: bucket, Key: "foo/bar/foo.txt", Body: "Hello!" })
         .promise();
       yield s3Client
-        .deleteObject({ Bucket: bucket, Key: "foo/foo.txt" })
+        .deleteObject({ Bucket: bucket, Key: "foo/bar/foo.txt" })
         .promise();
       yield s3Client.deleteBucket({ Bucket: bucket }).promise();
-    } catch (err) {
-      throw err;
     } finally {
       yield thunkToPromise(done => server.close(done));
     }
   });
 
-  it("Can put an object in a bucket that is empty after some key that does not include a directory has been deleted", function*() {
+  it("Can put an object in a bucket after all objects are deleted", function*() {
     const bucket = "foobars";
 
     let server;
@@ -1682,8 +1680,6 @@ describe("Data directory cleanup", function() {
       yield s3Client
         .putObject({ Bucket: bucket, Key: "foo2.txt", Body: "Hello2!" })
         .promise();
-    } catch (err) {
-      throw err;
     } finally {
       yield thunkToPromise(done => server.close(done));
     }


### PR DESCRIPTION
Resolves #375. The old implementation didn't check if the directory was empty after running the function on its children.