### PR TITLE
Ensure filesystem folder can be accessed under Linux

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -155,7 +155,7 @@ class FilesystemStore {
 
   putBucket(bucket, done) {
     const bucketPath = this.getBucketPath(bucket);
-    fs.mkdirp(bucketPath, 502, err => {
+    fs.mkdirp(bucketPath, 511/*0777*/, err => {
       if (err) return done(err);
       this.getBucket(bucket, done);
     });


### PR DESCRIPTION
When running under Linux (and probably Mac), new buckets are created without execute permissions, which makes it difficult to access properly through the filesystem.

This patch includes execute permissions (used to be able to see inside the folder).  These are then limited by the umask set by the user, reflecting the standard behaviour in other applications.