### PR TITLE
Support verification of signed requests and other special presigned request behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ $ s3rver --help
 Please see [Fake S3's wiki page](https://github.com/jubos/fake-s3/wiki/Supported-Clients) for a list of supported clients.
 When listening on HTTPS with a self-signed certificate, the AWS SDK in a Node.js environment will need `httpOptions: { agent: new https.Agent({ rejectUnauthorized: false }) }` in order to allow interaction.
 
+If your client only supports signed requests, specify the credentials
+
+```javascript
+{
+  accessKeyId: "S3RVER",
+  secretAccessKey: "S3RVER",
+}
+```
+
+in your client's configuration.
+
 Please test, if you encounter any problems please do not hesitate to open an issue :)
 
 ## Static Website Hosting

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -1,0 +1,508 @@
+"use strict";
+
+const { createHmac } = require("crypto");
+const { mapKeys, pickBy } = require("lodash");
+const querystring = require("querystring");
+
+const S3Error = require("../models/error");
+const { RESPONSE_HEADERS } = require("./response-header-override");
+const { parseDate, parseISO8601String } = require("../utils");
+
+/**
+ * Hardcoded dummy user used for authenticated requests.
+ */
+const DUMMY_USER = {
+  accountId: 123456789000,
+  accessKeyId: "S3RVER",
+  secretAccessKey: "S3RVER"
+};
+
+const SUBRESOURCES = {
+  acl: 1,
+  accelerate: 1,
+  analytics: 1,
+  cors: 1,
+  lifecycle: 1,
+  delete: 1,
+  inventory: 1,
+  location: 1,
+  logging: 1,
+  metrics: 1,
+  notification: 1,
+  partNumber: 1,
+  policy: 1,
+  requestPayment: 1,
+  replication: 1,
+  restore: 1,
+  tagging: 1,
+  torrent: 1,
+  uploadId: 1,
+  uploads: 1,
+  versionId: 1,
+  versioning: 1,
+  versions: 1,
+  website: 1
+};
+
+/**
+ * Middleware that verifies signed HTTP requests
+ *
+ * This also processes request and response headers specified via query params. Currently only S3
+ * (V2) signatures are fully supported. V4 signatures have incomplete support.
+ *
+ * {@link https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html}
+ */
+module.exports = () =>
+  async function authentication(ctx, next) {
+    if (ctx.state.website) {
+      // skip for static website requests
+      return next();
+    }
+
+    const query = mapKeys(ctx.query, (value, key) => key.toLowerCase());
+    const amzQueryHeaders = pickBy(
+      query,
+      (value, key) =>
+        key.startsWith("x-amz-") &&
+        // x-amz-website-redirect-location isn't a canonical header
+        key !== "x-amz-website-redirect-location"
+    );
+    // x-amz-* values specified in query params take precedence over those in the headers
+    Object.assign(ctx.headers, amzQueryHeaders);
+
+    const mechanisms = {
+      header: "authorization" in ctx.headers,
+      queryV2: "Signature" in ctx.query,
+      queryV4: "X-Amz-Algorithm" in ctx.query
+    };
+
+    const mechanismCount = Object.values(mechanisms).filter(Boolean).length;
+    if (mechanismCount === 0) {
+      return next();
+    }
+    if (mechanismCount !== 1) {
+      throw new S3Error(
+        "InvalidArgument",
+        "Only one auth mechanism allowed; only the X-Amz-Algorithm query " +
+          "parameter, Signature query string parameter or the Authorization " +
+          "header should be specified",
+        {
+          ArgumentName: "Authorization",
+          ArgumentValue: ctx.get("Authorization")
+        }
+      );
+    }
+
+    const canonicalizedAmzHeaders = Object.keys(ctx.headers)
+      .filter(
+        headerName =>
+          headerName.startsWith("x-amz-") &&
+          headerName !== "x-amz-website-redirect-location"
+      )
+      .sort()
+      .map(
+        headerName => `${headerName}:${ctx.get(headerName).replace(/ +/g, " ")}`
+      );
+    const canonicalizedQueryString = Object.keys(query)
+      .filter(
+        paramName =>
+          SUBRESOURCES[paramName] ||
+          RESPONSE_HEADERS[paramName] ||
+          (mechanisms.queryV4 && paramName.startsWith("x-amz-"))
+      )
+      .map(paramName =>
+        // v2 signing doesn't encode values in the signature calculation
+        mechanisms.queryV2
+          ? [paramName, query[paramName]].join("=")
+          : querystring.stringify({ [paramName]: query[paramName] })
+      )
+      .sort()
+      .join("&");
+
+    const canonicalRequest = {
+      method:
+        ctx.method === "OPTIONS"
+          ? ctx.get("Access-Control-Request-Method")
+          : ctx.method,
+      contentMD5: ctx.get("Content-MD5"),
+      contentType: ctx.get("Content-Type"),
+      timestamp: undefined,
+      uri: ctx.path,
+      querystring: canonicalizedQueryString,
+      amzHeaders: canonicalizedAmzHeaders
+    };
+
+    // begin parsing for each part of the signature algorithm and the rest of the canonical request
+    let signature;
+    let signatureProvided;
+    if (mechanisms.header) {
+      const result = parseHeader(ctx.headers);
+      ({ signature, signatureProvided } = result);
+      canonicalRequest.timestamp = result.timestamp;
+    } else if (mechanisms.queryV2) {
+      const result = parseQueryV2(ctx.query, ctx.headers);
+      ({ signature, signatureProvided } = result);
+      // S3 signing uses expiration time as timestamp
+      canonicalRequest.timestamp = result.expires;
+    } else if (mechanisms.queryV4) {
+      const result = parseQueryV4(ctx.query, ctx.headers);
+      ({ signature, signatureProvided } = result);
+      canonicalRequest.timestamp = result.timestamp;
+    }
+
+    let stringToSign;
+    if (signature.version === 2) {
+      stringToSign = getStringToSign(canonicalRequest);
+
+      const keys = enumerateSecretAccessKeys(signature.accessKeyId);
+      for (const signingKey of keys) {
+        const calculatedSignature = calculateSignature(
+          stringToSign,
+          signingKey,
+          signature.algorithm
+        );
+        if (signatureProvided === calculatedSignature) {
+          ctx.state.accountId = getAccountId(signature.accessKeyId);
+          break;
+        }
+      }
+    } else if (signature.version === 4) {
+      // Signature version 4 calculation is unimplemeneted
+      ctx.state.accountId = getAccountId(signature.accessKeyId);
+    }
+
+    if (!ctx.state.accountId) {
+      throw new S3Error(
+        "SignatureDoesNotMatch",
+        "The request signature we calculated does not match the signature you provided. Check " +
+          "your key and signing method.",
+        {
+          AWSAccessKeyId: signature.accessKeyId,
+          StringToSign: stringToSign,
+          StringToSignBytes: Buffer.from(stringToSign)
+            .toString("hex")
+            .match(/../g)
+            .join(" ")
+        }
+      );
+    }
+
+    return next();
+  };
+
+function parseHeader(headers) {
+  const signature = {
+    version: undefined,
+    algorithm: undefined,
+    accessKeyId: undefined
+  };
+  let signatureProvided;
+  const timestamp = headers["x-amz-date"] || headers["Date"];
+
+  const [algorithm, ...components] = headers["authorization"].split(" ");
+  switch (algorithm.toUpperCase()) {
+    case "AWS":
+      signature.version = 2;
+      signature.algorithm = "sha1";
+      break;
+    case "AWS4-HMAC-SHA256":
+      signature.version = 4;
+      signature.algorithm = "sha256";
+      break;
+    default:
+      throw new S3Error("InvalidArgument", "Unsupported Authorization Type", {
+        ArgumentName: "Authorization",
+        ArgumentValue: headers["authorization"]
+      });
+  }
+
+  if (signature.version === 2) {
+    if (components.length !== 1) {
+      throw new S3Error(
+        "InvalidArgument",
+        "Authorization header is invalid -- one and only one ' ' (space) required",
+        {
+          ArgumentName: "Authorization",
+          ArgumentValue: headers["authorization"]
+        }
+      );
+    }
+
+    const match = /([^:]*):([^:]+)/.exec(components[0]);
+    if (!match) {
+      throw new S3Error(
+        "InvalidArgument",
+        "AWS authorization header is invalid.  Expected AwsAccessKeyId:signature",
+        {
+          ArgumentName: "Authorization",
+          ArgumentValue: headers["authorization"]
+        }
+      );
+    }
+    signature.accessKeyId = match[1];
+    signatureProvided = match[2];
+  } else if (signature.version === 4) {
+    if (!("x-amz-content-sha256" in headers)) {
+      throw new S3Error(
+        "InvalidRequest",
+        "Missing required header for this request: x-amz-content-sha256"
+      );
+    }
+    if (
+      !headers["x-amz-content-sha256"].match(
+        /UNSIGNED-PAYLOAD|STREAMING-AWS4-HMAC-SHA256-PAYLOAD|[0-9A-Fa-f]{64}/
+      )
+    ) {
+      throw new S3Error(
+        "InvalidArgument",
+        "x-amz-content-sha256 must be UNSIGNED-PAYLOAD, " +
+          "STREAMING-AWS4-HMAC-SHA256-PAYLOAD, or a valid sha256 value.",
+        {
+          ArgumentName: "x-amz-content-sha256",
+          ArgumentValue: headers["x-amz-content-sha256"]
+        }
+      );
+    }
+
+    // skip payload verification
+
+    const componentMap = new Map(
+      components
+        .join("")
+        .split(",")
+        .map(component => {
+          const [key, ...value] = component.split("=");
+          return [key, value.join("=")];
+        })
+    );
+
+    if (componentMap.size !== 3) {
+      throw new S3Error(
+        "AuthorizationHeaderMalformed",
+        "The authorization header is malformed; the authorization header " +
+          "requires three components: Credential, SignedHeaders, and " +
+          "Signature."
+      );
+    }
+
+    for (const componentName of ["Credential", "SignedHeaders", "Signature"]) {
+      if (!componentMap.has(componentName)) {
+        throw new S3Error(
+          "AuthorizationHeaderMalformed",
+          `The authorization header is malformed; missing ${componentName}.`
+        );
+      }
+    }
+
+    // skip verification of each authorization header component
+
+    signature.accessKeyId = componentMap.get("Credential").split("/")[0];
+    signatureProvided = componentMap.get("Signature");
+  }
+
+  const serverTime = new Date();
+  const requestTime = parseDate(timestamp);
+  if (isNaN(requestTime)) {
+    throw new S3Error(
+      "AccessDenied",
+      "AWS authentication requires a valid Date or x-amz-date header"
+    );
+  }
+
+  if (Math.abs(serverTime - requestTime) > 900000) {
+    // 15 minutes
+    throw new S3Error(
+      "RequestTimeTooSkewed",
+      "The difference between the request time and the current time is too large.",
+      {
+        RequestTime: timestamp,
+        ServerTime: serverTime.toISOString().replace(/\.\d+/, "")
+      }
+    );
+  }
+  return {
+    signature,
+    signatureProvided,
+    timestamp
+  };
+}
+
+function parseQueryV2(query) {
+  // authentication param names are case-sensitive
+  if (!("Expires" in query) || !("AWSAccessKeyId" in query)) {
+    throw new S3Error(
+      "AccessDenied",
+      "Query-string authentication requires the Signature, Expires and " +
+        "AWSAccessKeyId parameters"
+    );
+  }
+
+  const signature = {
+    version: 2,
+    algorithm: "sha1",
+    accessKeyId: query["AWSAccessKeyId"]
+  };
+  const signatureProvided = query["Signature"];
+
+  const serverTime = new Date();
+  const expiresTime = new Date(Number(query["Expires"]) * 1000);
+  if (isNaN(expiresTime)) {
+    throw new S3Error(
+      "AccessDenied",
+      `Invalid date (should be seconds since epoch): ${query["Expires"]}`
+    );
+  }
+
+  if (serverTime > expiresTime) {
+    throw new S3Error("AccessDenied", "Request has expired", {
+      Expires: expiresTime.toISOString().replace(/\.\d+/, ""),
+      ServerTime: serverTime.toISOString().replace(/\.\d+/, "")
+    });
+  }
+
+  return {
+    signature,
+    signatureProvided,
+    expires: Number(query["Expires"])
+  };
+}
+
+function parseQueryV4(query) {
+  // query param values are case-sensitive
+  if (query["X-Amz-Algorithm"] !== "AWS4-HMAC-SHA256") {
+    throw new S3Error(
+      "AuthorizationQueryParametersError",
+      'X-Amz-Algorithm only supports "AWS4-HMAC-SHA256"'
+    );
+  }
+
+  const signature = {
+    version: 4,
+    algorithm: "sha256",
+    accessKeyId: undefined
+  };
+  let signatureProvided;
+
+  if (
+    !("X-Amz-Credential" in query) ||
+    !("X-Amz-Signature" in query) ||
+    !("X-Amz-Date" in query) ||
+    !("X-Amz-SignedHeaders" in query) ||
+    !("X-Amz-Expires" in query)
+  ) {
+    throw new S3Error(
+      "AuthorizationQueryParametersError",
+      "Query-string authentication version 4 requires the " +
+        "X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, " +
+        "X-Amz-SignedHeaders, and X-Amz-Expires parameters."
+    );
+  }
+  signature.accessKeyId = query["X-Amz-Credential"].split("/")[0];
+  signatureProvided = query["X-Amz-Signature"];
+
+  const timestamp = query["X-Amz-Date"];
+
+  const requestTime = parseISO8601String(timestamp);
+  if (isNaN(requestTime)) {
+    throw new S3Error(
+      "AuthorizationQueryParametersError",
+      "X-Amz-Date must be in the ISO8601 Long Format \"yyyyMMdd'T'HHmmss'Z'\""
+    );
+  }
+
+  const expires = Number(query["X-Amz-Expires"]);
+  if (isNaN(expires))
+    if (expires < 0) {
+      throw new S3Error(
+        "AuthorizationQueryParametersError",
+        "X-Amz-Expires must be non-negative"
+      );
+    }
+  if (expires > 604800) {
+    throw new S3Error(
+      "AuthorizationQueryParametersError",
+      "X-Amz-Expires must be less than a week (in seconds); that is, the " +
+        "given X-Amz-Expires must be less than 604800 seconds"
+    );
+  }
+
+  const serverTime = new Date();
+  // NOTE: S3 doesn't care about time skew for presigned requests
+  const expiresTime = new Date(requestTime + expires * 1000);
+
+  if (serverTime > expiresTime) {
+    throw new S3Error("AccessDenied", "Request has expired", {
+      "X-Amz-Expires": query["X-Amz-Expires"],
+      Expires: expiresTime.toISOString().replace(/\.\d+/, ""),
+      ServerTime: serverTime.toISOString().replace(/\.\d+/, "")
+    });
+  }
+
+  return {
+    signature,
+    signatureProvided,
+    timestamp
+  };
+}
+
+/**
+ * Generator that looks up secret keys for a given access key ID.
+ *
+ * @param {String} accessKeyId
+ */
+function* enumerateSecretAccessKeys(accessKeyId) {
+  if (accessKeyId === DUMMY_USER.accessKeyId) {
+    yield DUMMY_USER.secretAccessKey;
+  } else {
+    throw new S3Error(
+      "InvalidAccessKeyId",
+      "The AWS Access Key Id you provided does not exist in our records.",
+      { AWSAccessKeyId: accessKeyId }
+    );
+  }
+}
+
+/**
+ * Looks up an AWS account ID from an access key ID.
+ *
+ * @param {String} accessKeyId
+ */
+function getAccountId(accessKeyId) {
+  if (accessKeyId === DUMMY_USER.accessKeyId) {
+    return DUMMY_USER.accountId;
+  }
+}
+
+/**
+ * Generates a string to be signed for the specified signature version.
+ *
+ * (currently only generates strings for V2 signing)
+ *
+ * @param {*} canonicalRequest
+ */
+function getStringToSign(canonicalRequest) {
+  return [
+    canonicalRequest.method,
+    canonicalRequest.contentMD5,
+    canonicalRequest.contentType,
+    canonicalRequest.timestamp,
+    ...canonicalRequest.amzHeaders,
+    canonicalRequest.querystring
+      ? `${canonicalRequest.uri}?${canonicalRequest.querystring}`
+      : canonicalRequest.uri
+  ].join("\n");
+}
+
+/**
+ * Performs the calculation of an authentication code for a string using the specified key and
+ * algorithm.
+ *
+ * @param {String} stringToSign the string representation of a canonical request
+ * @param {String} signingKey a secret access key for V2 signing, or a signing key for V4 signing
+ * @param {String} algorithm should be one of "sha1" or "sha256"
+ */
+function calculateSignature(stringToSign, signingKey, algorithm) {
+  const signature = createHmac(algorithm, signingKey);
+  signature.update(stringToSign, "utf8");
+  return signature.digest("base64");
+}

--- a/lib/middleware/response-header-override.js
+++ b/lib/middleware/response-header-override.js
@@ -5,6 +5,10 @@ const { chain, isEmpty } = require("lodash");
 const S3Error = require("../models/error");
 const { capitalizeHeader } = require("../utils");
 
+/**
+ * Derived from
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html#RESTObjectGET-requests-request-parameters
+ */
 const RESPONSE_HEADERS = {
   "response-content-type": 1,
   "response-content-language": 1,

--- a/lib/middleware/response-header-override.js
+++ b/lib/middleware/response-header-override.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const { chain, isEmpty } = require("lodash");
+
+const S3Error = require("../models/error");
+const { capitalizeHeader } = require("../utils");
+
+const RESPONSE_HEADERS = {
+  "response-content-type": 1,
+  "response-content-language": 1,
+  "response-expires": 1,
+  "response-cache-control": 1,
+  "response-content-disposition": 1,
+  "response-content-encoding": 1
+};
+
+/**
+ * Middleware that handles response headers overrides on signed GET requests.
+ */
+exports = module.exports = () =>
+  async function responseHeaderOverride(ctx, next) {
+    if (ctx.state.website) {
+      // skip for static website requests
+      return next();
+    }
+
+    const overrides = chain(ctx.query)
+      .pickBy((value, key) => {
+        if (!key.startsWith("response-")) return false;
+        if (!RESPONSE_HEADERS[key]) {
+          throw new S3Error(
+            "InvalidArgument",
+            `${key} is not in the set of overridable response headers. ` +
+              "Please refer to the S3 API documentation for a complete list " +
+              "of overridable response headers.",
+            {
+              ArgumentName: key,
+              ArgumentValue: value
+            }
+          );
+        }
+        return true;
+      })
+      .mapKeys((value, key) => capitalizeHeader(key.slice("response-".length)))
+      .value();
+
+    switch (ctx.method) {
+      case "HEAD":
+      case "GET":
+        if (!isEmpty(overrides) && !ctx.state.accountId) {
+          throw new S3Error(
+            "InvalidRequest",
+            "Request specific response headers cannot be used for anonymous " +
+              "GET requests."
+          );
+        }
+        await next();
+        ctx.set(overrides);
+        break;
+      default:
+        return next();
+    }
+  };
+
+exports.RESPONSE_HEADERS = RESPONSE_HEADERS;

--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -31,22 +31,9 @@ exports = module.exports = () =>
     }
 
     const config = await ctx.store.getSubresource(bucket, undefined, "website");
-    if (config) {
-      ctx.state.websiteConfig = config;
-    }
     let isVirtualHost;
-
     if (ctx.hostname.match(/\.s3-website[-.].+\.amazonaws\.com$/)) {
-      // requests to a .s3-website-<region>.amazonaws.com vhost should throw website-specific errors
-      ctx.onerror = onerror;
       isVirtualHost = true;
-      if (!config) {
-        throw new S3Error(
-          "NoSuchWebsiteConfiguration",
-          "The specified bucket does not have a website configuration",
-          { BucketName: bucket }
-        );
-      }
     } else if (
       ctx.hostname.match(/(^|\.)s3([-.].+)?\.amazonaws\.com$/) ||
       !bucket ||
@@ -58,8 +45,18 @@ exports = module.exports = () =>
       // requests to the the API endpoint use normal output behavior
       // (vhost-style buckets without website configurations also always use this behavior)
       return next();
-    } else {
-      ctx.onerror = onerror;
+    }
+
+    ctx.onerror = onerror;
+    ctx.state.website = config || {};
+
+    if (isVirtualHost && !config) {
+      // throw website-specific errors for requests to a .s3-website-<region>.amazonaws.com vhost
+      throw new S3Error(
+        "NoSuchWebsiteConfiguration",
+        "The specified bucket does not have a website configuration",
+        { BucketName: bucket }
+      );
     }
 
     // disallow x-amz-* query params for website requests
@@ -200,16 +197,16 @@ async function onerror(err) {
     err.description = `${err.status} ${statuses[err.status]}`;
 
   // respond
-  const { websiteConfig = {} } = this.state;
+  const { website } = this.state;
   if (
     err.code !== "NoSuchBucket" &&
     err.code !== "UnsupportedQuery" &&
-    websiteConfig.errorDocumentKey
+    website.errorDocumentKey
   ) {
     // attempt to serve error document
     const object = await this.store.getObject(
       this.params.bucket,
-      websiteConfig.errorDocumentKey
+      website.errorDocumentKey
     );
     if (object) {
       const objectRedirectLocation =
@@ -227,12 +224,12 @@ async function onerror(err) {
       return;
     }
     this.logger.error(
-      "Custom Error Document not found: " + websiteConfig.errorDocumentKey
+      "Custom Error Document not found: " + website.errorDocumentKey
     );
     const errorDocumentErr = new S3Error(
       "NoSuchKey",
       "The specified key does not exist.",
-      { Key: websiteConfig.errorDocumentKey }
+      { Key: website.errorDocumentKey }
     );
     errorDocumentErr.description =
       "An Error Occurred While Attempting to Retrieve a Custom Error Document";

--- a/lib/models/error.js
+++ b/lib/models/error.js
@@ -164,6 +164,7 @@ const s3Statuses = {
   UserKeyMustBeSpecified: 400,
 
   // Additional errors not documented by the above
+  AuthorizationQueryParametersError: 400,
   BadRequest: 403,
   CORSResponse: 403,
   InvalidRedirectLocation: 400,

--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -9,8 +9,10 @@ const os = require("os");
 const path = require("path");
 const { callbackify, format, promisify } = require("util");
 
+const authenticationMiddleware = require("./middleware/authentication");
 const corsMiddleware = require("./middleware/cors");
 const loggerMiddleware = require("./middleware/logger");
+const responseHeaderOverrideMiddleware = require("./middleware/response-header-override");
 const vhostMiddleware = require("./middleware/vhost");
 const websiteMiddleware = require("./middleware/website");
 const { getConfigModel } = require("./models/config");
@@ -57,6 +59,8 @@ class S3rver extends Koa {
       this.use(vhostMiddleware());
       this.use(corsMiddleware());
       this.use(websiteMiddleware());
+      this.use(authenticationMiddleware());
+      this.use(responseHeaderOverrideMiddleware());
       this.use(router.routes());
     } catch (err) {
       this.logger.exceptions.unhandle();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,3 +62,46 @@ exports.getXmlRootTag = function(xml) {
   const [[root]] = Object.values(traversal.child);
   return root && root.tagname;
 };
+
+/**
+ * Inserts separators into AWS ISO8601 formatted-dates to make it parsable by JS.
+ *
+ * @param dateString
+ */
+exports.parseISO8601String = function(dateString) {
+  if (typeof dateString !== "string") {
+    return new Date(NaN);
+  }
+  // attempt to parse as ISO8601 with inserted separators
+  // yyyyMMddTHHmmssZ
+  //     ^ ^    ^ ^
+  const chars = [...dateString];
+  chars.splice(13, 0, ":");
+  chars.splice(11, 0, ":");
+  chars.splice(6, 0, "-");
+  chars.splice(4, 0, "-");
+  return new Date(chars.join(""));
+};
+
+/**
+ * Attempts to parse a dateString as a regular JS Date before falling back to
+ * AWS's "ISO8601 Long Format" date.
+ *
+ * @param dateString
+ */
+exports.parseDate = function(dateString) {
+  let date = new Date(dateString);
+  if (isNaN(date)) {
+    date = exports.parseISO8601String(dateString);
+  }
+  return date;
+};
+
+/**
+ * Like Date.prototype.toISOString(), but without separators and milliseconds.
+ *
+ * @param date
+ */
+exports.toISO8601String = function(date) {
+  return new Date(date).toISOString().replace(/[-:]|\.\d+/g, "");
+};


### PR DESCRIPTION
This includes full support for signature version 2 and partial support for version 4. This also supports specifing `x-amz-meta-*` headers via query parameters and overriding response headers via `response-*` query parameters.

The test suite is by no means comprehensive but should cover the most important errors typically encountered. There are a lot of edge cases that I've done my best to handle as accurately as possible.

Here's the list of the features currently not implemented in the signature version 4 implementation:
* Verification of a provided signature (and calculating signing keys)
* Verification of content hash for signed payloads
* Validation of each component of an Authorization header
* Well-formedness check of Credential, SignedHeaders, and Signature parameters
* Validation of the date of a Credential parameter
* Enforcement of the SignedHeaders component