### PR TITLE
handle s3rver launched with ip other than localhost

### DIFF
--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const net = require("net");
+
 /**
  * Middleware that rewrites URLs for buckets specified via subdomain or host header
  */
@@ -15,7 +17,7 @@ module.exports = () =>
       if (bucket) {
         ctx.path = `/${bucket}${ctx.path}`;
       }
-    } else if (ctx.hostname !== "localhost" && ctx.hostname !== "127.0.0.1") {
+    } else if (ctx.hostname !== "localhost" && !net.isIP(ctx.hostname)) {
       // otherwise attempt to distinguish virtual host-style requests
       ctx.path = `/${bucket}${ctx.path}`;
     }

--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -17,9 +17,9 @@ module.exports = () =>
       if (bucket) {
         ctx.path = `/${bucket}${ctx.path}`;
       }
-    } else if (ctx.hostname !== "localhost" && !net.isIP(ctx.hostname)) {
+    } else if (!net.isIP(ctx.hostname) && ctx.hostname !== "localhost") {
       // otherwise attempt to distinguish virtual host-style requests
-      ctx.path = `/${bucket}${ctx.path}`;
+      ctx.path = `/${ctx.hostname}${ctx.path}`;
     }
 
     return next();

--- a/test/test.js
+++ b/test/test.js
@@ -1264,13 +1264,22 @@ describe("S3rver Tests", function() {
     expect(find(data.Deleted, { Key: "doesnotexist" })).to.exist;
   });
 
-  it("should reach the server with a bucket vhost", async function() {
+  it("should reach the server with a bucket subdomain", async function() {
     const body = await request({
       url: s3Client.endpoint.href,
       headers: { host: buckets[0].name + ".s3.amazonaws.com" },
       json: true
     });
-    expect(body).to.include("ListBucketResult");
+    expect(body).to.include(`<Name>${buckets[0].name}</Name>`);
+  });
+
+  it("should reach the server with a bucket vhost", async function() {
+    const body = await request({
+      url: s3Client.endpoint.href,
+      headers: { host: buckets[0].name },
+      json: true
+    });
+    expect(body).to.include(`<Name>${buckets[0].name}</Name>`);
   });
 });
 


### PR DESCRIPTION
(for example docker environment), now we don't only test for ctx.hostname being 127.0.0.1, but any ip
other when using docker, you would end up with an ip in for example 172.12.0.6, and vhost.js would
have erroneously replaced ctx.path by  `/undefined/$bucketname`