### PR TITLE
Fully implement List Objects V2 with pagination response elements

### DIFF
--- a/lib/controllers/bucket.js
+++ b/lib/controllers/bucket.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { DUMMY_ACCOUNT } = require("../models/account");
 const S3Error = require("../models/error");
 const {
   S3CorsConfiguration,
@@ -146,8 +147,8 @@ exports.getBucket = async function getBucket(ctx) {
           Size: object.size,
           StorageClass: "STANDARD",
           Owner: {
-            ID: 123,
-            DisplayName: "S3rver"
+            ID: DUMMY_ACCOUNT.id,
+            DisplayName: DUMMY_ACCOUNT.displayName
           }
         }))
       }

--- a/lib/controllers/bucket.js
+++ b/lib/controllers/bucket.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const crypto = require("crypto");
+
 const { DUMMY_ACCOUNT } = require("../models/account");
 const S3Error = require("../models/error");
 const {
@@ -15,6 +17,34 @@ async function utf8BodyParser(ctx) {
     req.on("end", () => resolve(payload));
     req.on("error", reject);
   });
+}
+
+function generateContinuationToken(bucket, keyName, region) {
+  const key = Buffer.alloc(8, "S3RVER", "utf8");
+  const iv = crypto.randomBytes(8);
+  // ensure the first byte of IV lies between [212, 216)
+  iv[0] = (iv[0] & 0b00000011) | 0b11010100;
+  // use DES for its 8-byte block size
+  // (real S3 has blocks of lengths [9,8,7] repeating)
+  const cipher = crypto.createCipheriv("des", key, iv);
+  return Buffer.concat([
+    iv,
+    cipher.update(`${region}/${bucket}/${keyName}`, "utf8"),
+    cipher.final()
+  ]).toString("base64");
+}
+
+function decipherContinuationToken(token) {
+  const buf = Buffer.from(token, "base64");
+  if (buf.length < 8) return "";
+  const key = Buffer.alloc(8, "S3RVER", "utf8");
+  const iv = buf.slice(0, 8);
+  const decipher = crypto.createDecipheriv("des", key, iv);
+  const ciphertext = buf.slice(8);
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final()
+  ]).toString("utf8");
 }
 
 exports.bucketExists = async function bucketExists(ctx, next) {
@@ -112,44 +142,150 @@ exports.deleteBucketWebsite = async function deleteBucketWebsite(ctx) {
  */
 exports.getBucket = async function getBucket(ctx) {
   const options = {
-    delimiter: ctx.query["delimiter"],
-    marker: ctx.query["marker"],
-    maxKeys: Math.min(1000, Number(ctx.query["max-keys"]) || Infinity),
-    prefix: ctx.query["prefix"]
+    delimiter: ctx.query["delimiter"] || undefined,
+    encodingType: ctx.query["encoding-type"], // currently unimplemented
+    maxKeys: 1000,
+    startAfter: undefined,
+    prefix: ctx.query["prefix"] || undefined,
+    fetchOwner: undefined
   };
+  if (ctx.query["max-keys"]) {
+    if (!ctx.query["max-keys"].match(/^-?\d+$/)) {
+      throw new S3Error(
+        "InvalidArgument",
+        "Provided max-keys not an integer or within integer range",
+        {
+          ArgumentName: "max-keys",
+          ArgumentValue: ctx.query["max-keys"]
+        }
+      );
+    }
+    const maxKeys = Number(ctx.query["max-keys"]);
+    if (maxKeys < 0 || 2147483647 < maxKeys) {
+      throw new S3Error(
+        "InvalidArgument",
+        "Argument maxKeys must be an integer between 0 and 2147483647",
+        {
+          ArgumentName: "maxKeys",
+          ArgumentValue: maxKeys
+        }
+      );
+    }
+    options.maxKeys = Math.min(1000, maxKeys);
+  }
+  switch (ctx.query["list-type"]) {
+    case "2":
+      if ("marker" in ctx.query) {
+        throw new S3Error(
+          "InvalidArgument",
+          "Marker unsupported with REST.GET.BUCKET in list-type=2",
+          { ArgumentName: "marker" }
+        );
+      }
+      if (ctx.query["continuation-token"]) {
+        const token = decipherContinuationToken(
+          ctx.query["continuation-token"]
+        );
+        const [, region, bucket, startAfter] =
+          /([\w-.]+)\/([\w-.]+)\/(.+)/.exec(token) || [];
+        if (region !== "us-east-1" || bucket !== ctx.params.bucket) {
+          throw new S3Error(
+            "InvalidArgument",
+            "The continuation token provided is incorrect",
+            { ArgumentName: "continuation-token" }
+          );
+        }
+        options.startAfter = startAfter;
+      } else {
+        options.startAfter = ctx.query["start-after"];
+      }
+      options.fetchOwner = ctx.query["fetch-owner"] === "true";
+      break;
+    default:
+      // fall back to version 1
+      if ("continuation-token" in ctx.query) {
+        throw new S3Error(
+          "InvalidArgument",
+          "continuation-token only supported in REST.GET.BUCKET with list-type=2",
+          { ArgumentName: "continuation-token" }
+        );
+      }
+      if ("start-after" in ctx.query) {
+        throw new S3Error(
+          "InvalidArgument",
+          // yes, for some reason they decided to camelCase the start-after argument in this error message
+          "startAfter only supported in REST.GET.BUCKET with list-type=2",
+          { ArgumentName: "start-after" }
+        );
+      }
+      options.fetchOwner = true;
+      options.startAfter = ctx.query["marker"];
+      break;
+  }
   ctx.logger.info(
     'Fetched bucket "%s" with options %s',
     ctx.params.bucket,
     options
   );
   try {
-    const results = await ctx.store.listObjects(ctx.params.bucket, options);
+    const result =
+      options.maxKeys === 0
+        ? {
+            objects: [],
+            commonPrefixes: [],
+            isTruncated: false
+          }
+        : await ctx.store.listObjects(ctx.params.bucket, options);
     ctx.logger.info(
       'Found %d objects for bucket "%s"',
-      results.objects.length,
+      result.objects.length,
       ctx.params.bucket
     );
     ctx.body = {
       ListBucketResult: {
         "@": { xmlns: "http://doc.s3.amazonaws.com/2006-03-01/" },
-        IsTruncated: results.isTruncated || false,
-        Marker: options.marker || "",
         Name: ctx.params.bucket,
-        Prefix: options.prefix || "",
-        MaxKeys: options.maxKeys,
-        CommonPrefixes: results.commonPrefixes.map(prefix => ({
-          Prefix: prefix
-        })),
-        Contents: results.objects.map(object => ({
+        Prefix: options.prefix || "", // never omit
+        ...(ctx.query["list-type"] === "2"
+          ? {
+              StartAfter: ctx.query["continuation-token"]
+                ? undefined
+                : options.startAfter,
+              ContinuationToken: ctx.query["continuation-token"] || undefined,
+              NextContinuationToken: result.isTruncated
+                ? generateContinuationToken(
+                    ctx.params.bucket,
+                    result.objects[result.objects.length - 1].key,
+                    "us-east-1"
+                  )
+                : undefined,
+              KeyCount: result.objects.length
+            }
+          : {
+              Marker: options.startAfter || "", // never omit
+              NextMarker:
+                options.delimiter && result.isTruncated
+                  ? result.objects[result.objects.length - 1].key
+                  : undefined
+            }),
+        MaxKeys: ctx.query["max-keys"] || 1000, // S3 has a hard limit at 1000 but will still echo back the original input
+        Delimiter: options.delimiter || undefined, // omit when "" or undefined
+        IsTruncated: result.isTruncated || false,
+        Contents: result.objects.map(object => ({
           Key: object.key,
           LastModified: object.lastModifiedDate.toISOString(),
           ETag: object.metadata["etag"],
           Size: object.size,
-          StorageClass: "STANDARD",
-          Owner: {
-            ID: DUMMY_ACCOUNT.id,
-            DisplayName: DUMMY_ACCOUNT.displayName
-          }
+          Owner: options.fetchOwner
+            ? {
+                ID: DUMMY_ACCOUNT.id,
+                DisplayName: DUMMY_ACCOUNT.displayName
+              }
+            : undefined,
+          StorageClass: "STANDARD"
+        })),
+        CommonPrefixes: result.commonPrefixes.map(prefix => ({
+          Prefix: prefix
         }))
       }
     };

--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -4,6 +4,7 @@ const crypto = require("crypto");
 const xmlParser = require("fast-xml-parser");
 const he = require("he");
 
+const { DUMMY_ACCOUNT } = require("../models/account");
 const S3Error = require("../models/error");
 const S3Event = require("../models/event");
 const S3Object = require("../models/object");
@@ -208,8 +209,8 @@ exports.getObjectAcl = async function getObjectAcl(ctx) {
     AccessControlPolicy: {
       "@": { xmlns: "http://doc.s3.amazonaws.com/2006-03-01/" },
       Owner: {
-        ID: 123,
-        DisplayName: "S3rver"
+        ID: DUMMY_ACCOUNT.id,
+        DisplayName: DUMMY_ACCOUNT.displayName
       },
       AccessControlList: {
         Grant: {

--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -2,6 +2,7 @@
 
 const crypto = require("crypto");
 const xmlParser = require("fast-xml-parser");
+const he = require("he");
 
 const S3Error = require("../models/error");
 const S3Event = require("../models/event");
@@ -23,7 +24,9 @@ async function xmlBodyParser(ctx) {
         "our published schema."
     );
   }
-  ctx.request.body = xmlParser.parse(xmlString);
+  ctx.request.body = xmlParser.parse(xmlString, {
+    tagValueProcessor: a => he.decode(a)
+  });
 }
 
 function triggerS3Event(ctx, eventData) {

--- a/lib/controllers/service.js
+++ b/lib/controllers/service.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { DUMMY_ACCOUNT } = require("../models/account");
+
 /*
  * Operations on Buckets
  * The following methods correspond to operations you can perform on the Amazon S3 service.
@@ -19,8 +21,8 @@ exports.getService = async function getService(ctx) {
     ListAllMyBucketsResult: {
       "@": { xmlns: "http://doc.s3.amazonaws.com/2006-03-01/" },
       Owner: {
-        ID: 123,
-        DisplayName: "S3rver"
+        ID: DUMMY_ACCOUNT.id,
+        DisplayName: DUMMY_ACCOUNT.displayName
       },
       Buckets: {
         Bucket: buckets.map(bucket => ({

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -4,18 +4,10 @@ const { createHmac } = require("crypto");
 const { mapKeys, pickBy } = require("lodash");
 const querystring = require("querystring");
 
+const AWSAccount = require("../models/account");
 const S3Error = require("../models/error");
 const { RESPONSE_HEADERS } = require("./response-header-override");
 const { parseDate, parseISO8601String } = require("../utils");
-
-/**
- * Hardcoded dummy user used for authenticated requests.
- */
-const DUMMY_USER = {
-  accountId: 123456789000,
-  accessKeyId: "S3RVER",
-  secretAccessKey: "S3RVER"
-};
 
 const SUBRESOURCES = {
   acl: 1,
@@ -151,27 +143,33 @@ module.exports = () =>
     }
 
     let stringToSign;
+    const account = AWSAccount.registry.get(signature.accessKeyId);
+    if (!account) {
+      throw new S3Error(
+        "InvalidAccessKeyId",
+        "The AWS Access Key Id you provided does not exist in our records.",
+        { AWSAccessKeyId: signature.accessKeyId }
+      );
+    }
+
     if (signature.version === 2) {
       stringToSign = getStringToSign(canonicalRequest);
 
-      const keys = enumerateSecretAccessKeys(signature.accessKeyId);
-      for (const signingKey of keys) {
-        const calculatedSignature = calculateSignature(
-          stringToSign,
-          signingKey,
-          signature.algorithm
-        );
-        if (signatureProvided === calculatedSignature) {
-          ctx.state.accountId = getAccountId(signature.accessKeyId);
-          break;
-        }
+      const signingKey = account.accessKeys.get(signature.accessKeyId);
+      const calculatedSignature = calculateSignature(
+        stringToSign,
+        signingKey,
+        signature.algorithm
+      );
+      if (signatureProvided === calculatedSignature) {
+        ctx.state.account = account;
       }
     } else if (signature.version === 4) {
       // Signature version 4 calculation is unimplemeneted
-      ctx.state.accountId = getAccountId(signature.accessKeyId);
+      ctx.state.account = account;
     }
 
-    if (!ctx.state.accountId) {
+    if (!ctx.state.account) {
       throw new S3Error(
         "SignatureDoesNotMatch",
         "The request signature we calculated does not match the signature you provided. Check " +
@@ -443,34 +441,6 @@ function parseQueryV4(query) {
     signatureProvided,
     timestamp
   };
-}
-
-/**
- * Generator that looks up secret keys for a given access key ID.
- *
- * @param {String} accessKeyId
- */
-function* enumerateSecretAccessKeys(accessKeyId) {
-  if (accessKeyId === DUMMY_USER.accessKeyId) {
-    yield DUMMY_USER.secretAccessKey;
-  } else {
-    throw new S3Error(
-      "InvalidAccessKeyId",
-      "The AWS Access Key Id you provided does not exist in our records.",
-      { AWSAccessKeyId: accessKeyId }
-    );
-  }
-}
-
-/**
- * Looks up an AWS account ID from an access key ID.
- *
- * @param {String} accessKeyId
- */
-function getAccountId(accessKeyId) {
-  if (accessKeyId === DUMMY_USER.accessKeyId) {
-    return DUMMY_USER.accountId;
-  }
 }
 
 /**

--- a/lib/middleware/response-header-override.js
+++ b/lib/middleware/response-header-override.js
@@ -51,7 +51,7 @@ exports = module.exports = () =>
     switch (ctx.method) {
       case "HEAD":
       case "GET":
-        if (!isEmpty(overrides) && !ctx.state.accountId) {
+        if (!isEmpty(overrides) && !ctx.state.account) {
           throw new S3Error(
             "InvalidRequest",
             "Request specific response headers cannot be used for anonymous " +

--- a/lib/models/account.js
+++ b/lib/models/account.js
@@ -1,0 +1,27 @@
+"use strict";
+
+class AWSAccount {
+  constructor(accountId, displayName) {
+    this.id = accountId;
+    this.displayName = displayName;
+    this.accessKeys = new Map();
+  }
+
+  createKeyPair(accessKeyId, secretAccessKey) {
+    AWSAccount.registry.set(accessKeyId, this);
+    this.accessKeys.set(accessKeyId, secretAccessKey);
+  }
+
+  revokeAccessKey(accessKeyId) {
+    AWSAccount.registry.delete(accessKeyId);
+    this.accessKeys.delete(accessKeyId);
+  }
+}
+AWSAccount.registry = new Map();
+
+exports = module.exports = AWSAccount;
+
+// Hardcoded dummy user used for authenticated requests
+exports.DUMMY_ACCOUNT = new AWSAccount(123456789000, "S3rver");
+exports.DUMMY_ACCOUNT.createKeyPair("S3RVER", "S3RVER");
+

--- a/lib/models/account.js
+++ b/lib/models/account.js
@@ -24,4 +24,3 @@ exports = module.exports = AWSAccount;
 // Hardcoded dummy user used for authenticated requests
 exports.DUMMY_ACCOUNT = new AWSAccount(123456789000, "S3rver");
 exports.DUMMY_ACCOUNT.createKeyPair("S3RVER", "S3RVER");
-

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -14,9 +14,6 @@ exports.getConfigModel = function getConfigModel(type) {
   }
 };
 
-/**
- * Abstract class used
- */
 class S3ConfigBase {
   /**
    * Validates a given XML config against S3's spec.

--- a/lib/models/error.js
+++ b/lib/models/error.js
@@ -2,6 +2,7 @@
 
 const { mapKeys, omit } = require("lodash");
 const { j2xParser } = require("fast-xml-parser");
+const he = require("he");
 
 class S3Error extends Error {
   static fromError(err) {
@@ -31,7 +32,9 @@ class S3Error extends Error {
   }
 
   toXML() {
-    const parser = new j2xParser();
+    const parser = new j2xParser({
+      tagValueProcessor: a => he.encode(a, { useNamedReferences: true })
+    });
     return [
       '<?xml version="1.0" encoding="UTF-8"?>',
       parser.parse({
@@ -45,29 +48,30 @@ class S3Error extends Error {
   }
 
   toHTML() {
+    const encode = a => he.encode(a, { useNamedReferences: true });
     return [
       // Real S3 doesn't respond with DOCTYPE
       "<html>",
       // prettier-ignore
-      `<head><title>${this.description}</title></head>`,
+      `<head><title>${encode(this.description)}</title></head>`,
       "<body>",
-      `<h1>${this.description}</h1>`,
+      `<h1>${encode(this.description)}</h1>`,
       "<ul>",
-      `<li>Code: ${this.code}</li>`,
+      `<li>Code: ${encode(this.code)}</li>`,
       `<li>Message: ${this.message}</li>`,
       Object.entries(this.detail)
-        .map(([key, value]) => `<li>${key}: ${value}</li>`)
+        .map(([key, value]) => `<li>${key}: ${encode(value)}</li>`)
         .join("\n"),
       "</ul>",
       (this.errors || [])
         .map(error =>
           [
-            `<h3>${error.description}</h3>`,
+            `<h3>${encode(error.description)}</h3>`,
             "<ul>",
-            `<li>Code: ${error.code}</li>`,
-            `<li>Message: ${error.message}</li>`,
+            `<li>Code: ${encode(error.code)}</li>`,
+            `<li>Message: ${encode(error.message)}</li>`,
             Object.entries(error.detail)
-              .map(([key, value]) => `<li>${key}: ${value}</li>`)
+              .map(([key, value]) => `<li>${key}: ${encode(value)}</li>`)
               .join("\n"),
             "</ul>"
           ].join("\n")

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -1,12 +1,8 @@
 "use strict";
+
 const crypto = require("crypto");
 
-function randomString(length) {
-  return crypto
-    .randomBytes(32)
-    .toString("hex")
-    .slice(0, length);
-}
+const { randomHexString } = require("../utils");
 
 class S3Event {
   constructor(eventData, reqParams) {
@@ -50,13 +46,13 @@ class S3Event {
           eventTime: new Date().toISOString(),
           eventName: eventName,
           userIdentity: {
-            principalId: "AWS:" + randomString(21).toUpperCase()
+            principalId: "AWS:" + randomHexString(21).toUpperCase()
           },
           requestParameters: {
             sourceIPAddress: sourceIp
           },
           responseElements: {
-            "x-amz-request-id": randomString(16).toUpperCase(),
+            "x-amz-request-id": randomHexString(16).toUpperCase(),
             "x-amz-id-2": crypto
               .createHash("sha256")
               .update(reqHeaders.host)
@@ -68,7 +64,7 @@ class S3Event {
             bucket: {
               name: eventData.bucket,
               ownerIdentity: {
-                principalId: randomString(14).toUpperCase()
+                principalId: randomHexString(14).toUpperCase()
               },
               arn: "arn:aws:s3: : :" + eventData.bucket
             },

--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -3,6 +3,7 @@
 const xmlParser = require("fast-xml-parser");
 const Koa = require("koa");
 const { defaults, isPlainObject } = require("lodash");
+const he = require("he");
 const http = require("http");
 const https = require("https");
 const os = require("os");
@@ -45,7 +46,8 @@ class S3rver extends Koa {
       // encode object responses as XML
       const parser = new xmlParser.j2xParser({
         ignoreAttributes: false,
-        attrNodeName: "@"
+        attrNodeName: "@",
+        tagValueProcessor: a => he.encode(a, { useNamedReferences: true })
       });
       this.use(async (ctx, next) => {
         await next();

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -140,44 +140,75 @@ class FilesystemStore {
   }
 
   async listObjects(bucket, options) {
+    const {
+      delimiter = "",
+      startAfter = "",
+      prefix = "",
+      maxKeys = Infinity
+    } = options;
     const bucketPath = this.getBucketPath(bucket);
+
+    const delimiterEnc = FilesystemStore.encodeKeyPath(delimiter);
+    const startAfterPath = [
+      bucketPath,
+      FilesystemStore.encodeKeyPath(startAfter)
+    ].join("/");
+    const prefixPath = [bucketPath, FilesystemStore.encodeKeyPath(prefix)].join(
+      "/"
+    );
+
+    const it = walk(bucketPath, dirPath => {
+      // avoid directories occurring before the startAfter parameter
+      if (dirPath < startAfterPath && startAfterPath.indexOf(dirPath) === -1) {
+        return false;
+      }
+      if (dirPath.startsWith(prefixPath)) {
+        if (
+          delimiterEnc &&
+          dirPath.slice(prefixPath.length).indexOf(delimiterEnc) !== -1
+        ) {
+          // avoid directories occurring beneath a common prefix
+          return false;
+        }
+      } else if (!prefixPath.startsWith(dirPath)) {
+        // avoid directories that do not intersect with any part of the prefix
+        return false;
+      }
+      return true;
+    });
+
     const commonPrefixes = new Set();
     const objectSuffix = format(S3RVER_SUFFIX, "", "object");
-    let keys = [...walk(bucketPath)]
-      .filter(file => file.endsWith(objectSuffix))
-      .map(keyPath =>
+    const keys = [];
+    let isTruncated = false;
+    for (const keyPath of it) {
+      if (!keyPath.endsWith(objectSuffix)) {
+        continue;
+      }
+
+      const key = FilesystemStore.decodeKeyPath(
         keyPath.slice(bucketPath.length + 1, -objectSuffix.length)
-      )
-      .map(FilesystemStore.decodeKeyPath);
-
-    if (!keys.length) {
-      return {
-        objects: [],
-        commonPrefixes: [],
-        isTruncated: false
-      };
-    }
-
-    if (options.prefix) {
-      keys = keys.filter(key => key.startsWith(options.prefix));
-    }
-
-    if (options.delimiter) {
-      const prefix = options.prefix || "";
-      keys = keys.filter(key => {
-        const idx = key.slice(prefix.length).indexOf(options.delimiter);
-        if (idx === -1) return true;
-        // Add to common prefixes before we filter this key out
-        commonPrefixes.add(key.slice(0, prefix.length + idx + 1));
-        return false;
-      });
-    }
-
-    keys.sort();
-    if (options.marker) {
-      keys = keys.slice(
-        keys.findIndex(key => key.startsWith(options.marker)) + 1
       );
+
+      if (key <= startAfter || !key.startsWith(prefix)) {
+        continue;
+      }
+
+      if (delimiter) {
+        const idx = key.slice(prefix.length).indexOf(delimiter);
+        if (idx !== -1) {
+          // add to common prefixes before filtering this key out
+          commonPrefixes.add(key.slice(0, prefix.length + idx + 1));
+          continue;
+        }
+      }
+
+      if (keys.length < maxKeys) {
+        keys.push(key);
+      } else {
+        isTruncated = true;
+        break;
+      }
     }
 
     const metadataArr = await Promise.all(
@@ -188,14 +219,13 @@ class FilesystemStore {
         })
       )
     );
-    const objects = zip(keys, metadataArr)
-      .filter(([, metadata]) => !!metadata)
-      .map(([key, metadata]) => new S3Object(bucket, key, null, metadata));
 
     return {
-      objects: objects.slice(0, options.maxKeys),
+      objects: zip(keys, metadataArr)
+        .filter(([, metadata]) => metadata !== undefined)
+        .map(([key, metadata]) => new S3Object(bucket, key, null, metadata)),
       commonPrefixes: [...commonPrefixes].sort(),
-      isTruncated: objects.length > options.maxKeys
+      isTruncated
     };
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,14 +6,14 @@ const fs = require("fs-extra");
 const path = require("path");
 const { PassThrough } = require("stream");
 
-exports.walk = function* walk(dir) {
+exports.walk = function* walk(dir, recurseFilter) {
   for (const filename of fs.readdirSync(dir)) {
     const filePath = path.posix.join(dir, filename);
     const stats = fs.statSync(filePath);
     if (!stats.isDirectory()) {
       yield filePath;
-    } else {
-      yield* walk(filePath);
+    } else if (!recurseFilter || recurseFilter(filePath)) {
+      yield* walk(filePath, recurseFilter);
     }
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,10 @@
 "use strict";
 
+const crypto = require("crypto");
+const xmlParser = require("fast-xml-parser");
 const fs = require("fs-extra");
 const path = require("path");
 const { PassThrough } = require("stream");
-const xmlParser = require("fast-xml-parser");
 
 exports.walk = function* walk(dir) {
   for (const filename of fs.readdirSync(dir)) {
@@ -61,6 +62,20 @@ exports.getXmlRootTag = function(xml) {
   const traversal = xmlParser.getTraversalObj(xml.toString());
   const [[root]] = Object.values(traversal.child);
   return root && root.tagname;
+};
+
+exports.randomBase64String = function(length) {
+  return crypto
+    .randomBytes(Math.ceil((length * 3) / 4))
+    .toString("base64")
+    .slice(0, length);
+};
+
+exports.randomHexString = function(length) {
+  return crypto
+    .randomBytes(Math.ceil(length / 2))
+    .toString("hex")
+    .slice(0, length);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "commander": "^2.6.0",
     "fast-xml-parser": "^3.12.13",
     "fs-extra": "^7.0.0",
+    "he": "^1.2.0",
     "koa": "^2.7.0",
     "koa-logger": "^3.2.0",
     "koa-router": "^7.4.0",


### PR DESCRIPTION
Resolves #110. This implements "starts-after" for GET Bucket v2 as well all pagination-related response data for both the v1 and v2 APIs. This also fixes the behavior for "marker"/"starts-after" (they erroneously require a key starting with the marker to exist in order to work properly).

I also ended up doing some significant refactoring to the tests around listObjects since they weren't very strict and also ran very slowly (it actually isn't necessary to generate 1000+ objects to make adequate test cases most of the time).