### PR TITLE
Make http compatible with Node.js < 8.15.0, fix TypeError: "listener" argument must be a function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8.10.0"
   - "8"
   - "10"
   - "11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.10.0"
+  - "8.10.0" # Support latest AWS Lambda 8.x release
   - "8"
   - "10"
   - "11"

--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -141,19 +141,19 @@ class S3rver extends Koa {
 
   listen(...args) {
     const { key, cert, pfx } = this.serverOptions;
-    const httpModule = (key && cert) || pfx ? https : http;
+    const server =
+      (key && cert) || pfx
+        ? https.createServer(this.serverOptions)
+        : http.createServer(); // Node < 8.12 does not support http.createServer([options])
 
     const [callback] = args.slice(-1);
-    const server = httpModule
-      .createServer(this.serverOptions)
-      .on("request", this.callback())
-      .on("close", () => {
-        this.logger.exceptions.unhandle();
-        this.logger.close();
-        if (this.resetOnClose) {
-          this.reset();
-        }
-      });
+    server.on("request", this.callback()).on("close", () => {
+      this.logger.exceptions.unhandle();
+      this.logger.close();
+      if (this.resetOnClose) {
+        this.reset();
+      }
+    });
     if (typeof callback === "function") {
       return server.listen(...args);
     } else {


### PR DESCRIPTION
  Make compatible with node < 8.15.0

  `http.createServer` does not accept a serverOptions object in node.js < 8.15.0, so pass undefined.

  When https or node >= 8.15 pass serverOptions into createServer.

  Use semver to determine the version of Node.js that is running.

  This fixes an error when running in Node 8.10.0 (the version AWS lambda currently uses).

  ```
         TypeError: "listener" argument must be a function
          at new Server (_http_server.js:269:10)
          at Object.createServer (http.js:34:10)
          at S3rver.listen (lib/s3rver.js:148:8)
          at runAsync (lib/s3rver.js:130:36)
  ```