### PR TITLE
Report NotImplemented for stubbed routes

### DIFF
--- a/lib/controllers/bucket.js
+++ b/lib/controllers/bucket.js
@@ -43,6 +43,7 @@ exports.METHODS = [
   "encryption",
   "inventory",
   "lifecycle",
+  "location",
   "metrics",
   "notification",
   "object-lock",

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -62,8 +62,10 @@ router
       case "policy":
       case "replication":
       case "tagging":
-        ctx.throw(501);
-        break;
+        throw new S3Error(
+          "NotImplemented",
+          "A parameter you provided implies functionality that is not implemented"
+        );
       default:
         ctx.state.methodIsNotAllowed = true;
     }
@@ -93,8 +95,10 @@ router
       case "tagging":
       case "uploads":
       case "versioning":
-        ctx.throw(501);
-        break;
+        throw new S3Error(
+          "NotImplemented",
+          "A parameter you provided implies functionality that is not implemented"
+        );
       default:
         ctx.state.methodIsNotAllowed = true;
     }
@@ -133,8 +137,10 @@ router
       case "requestPayment":
       case "tagging":
       case "versioning":
-        ctx.throw(501);
-        break;
+        throw new S3Error(
+          "NotImplemented",
+          "A parameter you provided implies functionality that is not implemented"
+        );
       default:
         ctx.state.methodIsNotAllowed = true;
     }
@@ -148,8 +154,7 @@ router
       case undefined:
         return objectCtrl.deleteObject(ctx);
       case "tagging":
-        ctx.throw(501);
-        break;
+        throw new S3Error("NotImplemented");
       default:
         ctx.state.methodIsNotAllowed = true;
     }
@@ -164,8 +169,10 @@ router
       case "retention":
       case "tagging":
       case "torrent":
-        ctx.throw(501);
-        break;
+        throw new S3Error(
+          "NotImplemented",
+          "A parameter you provided implies functionality that is not implemented"
+        );
       default:
         ctx.state.methodIsNotAllowed = true;
     }
@@ -178,8 +185,7 @@ router
         return objectCtrl.initiateMultipartUpload(ctx);
       case undefined:
       case "select":
-        ctx.throw(501);
-        break;
+        throw new S3Error("NotImplemented");
       default:
         ctx.state.methodIsNotAllowed = true;
     }
@@ -194,8 +200,10 @@ router
         return objectCtrl.uploadPart(ctx);
       case "acl":
       case "tagging":
-        ctx.throw(501);
-        break;
+        throw new S3Error(
+          "NotImplemented",
+          "A parameter you provided implies functionality that is not implemented"
+        );
       default:
         ctx.state.methodIsNotAllowed = true;
     }


### PR DESCRIPTION
The route handlers weren't using the S3Error model used to format error responses for 501 errors. This also adds `location` to the list of bucket methods to fix #439.