### PR TITLE
Add md5 extension to md5 file

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -334,7 +334,7 @@ class FilesystemStore {
             this.getResourcePath(srcBucket, srcKey, "object.md5"),
             this.getResourcePath(destBucket, destKey, "object.md5")
           )
-        ])
+        ]);
       }
       return this.getMetadata(destBucket, destKey);
     }

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -74,7 +74,7 @@ class FilesystemStore {
             stream.on("data", chunk => md5Context.update(chunk, "utf8"));
             stream.on("end", () => resolve(md5Context.digest("hex")));
           });
-          await fs.writeFile(objectPath, md5);
+          await fs.writeFile(`${objectPath}.md5`, md5);
           return md5;
         })
     ]);

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -325,10 +325,16 @@ class FilesystemStore {
       return this.getMetadata(destBucket, destKey);
     } else {
       if (srcObjectPath !== destObjectPath) {
-        await fs.copy(
-          this.getResourcePath(srcBucket, srcKey, "metadata.json"),
-          this.getResourcePath(destBucket, destKey, "metadata.json")
-        );
+        await Promise.all([
+          fs.copy(
+            this.getResourcePath(srcBucket, srcKey, "metadata.json"),
+            this.getResourcePath(destBucket, destKey, "metadata.json")
+          ),
+          fs.copy(
+            this.getResourcePath(srcBucket, srcKey, "object.md5"),
+            this.getResourcePath(destBucket, destKey, "object.md5")
+          )
+        ])
       }
       return this.getMetadata(destBucket, destKey);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -521,7 +521,7 @@ describe("S3rver Tests", function() {
     const object = await s3Client
       .getObject({
         Bucket: buckets[3].name,
-        Key: destKey,
+        Key: destKey
       })
       .promise();
     expect(object.ETag).to.equal(data.ETag);

--- a/test/test.js
+++ b/test/test.js
@@ -518,6 +518,13 @@ describe("S3rver Tests", function() {
       .promise();
     expect(copyResult.ETag).to.equal(data.ETag);
     expect(moment(copyResult.LastModified).isValid()).to.be.true;
+    const object = await s3Client
+      .getObject({
+        Bucket: buckets[3].name,
+        Key: destKey,
+      })
+      .promise();
+    expect(object.ETag).to.equal(data.ETag);
   });
 
   it("should copy an image object into another bucket including its metadata", async function() {
@@ -550,6 +557,7 @@ describe("S3rver Tests", function() {
       .promise();
     expect(object.Metadata).to.have.property("somekey", "value");
     expect(object.ContentType).to.equal("image/jpeg");
+    expect(object.ETag).to.equal(data.ETag);
   });
 
   it("should copy an object using spaces/unicode chars in keys", async function() {


### PR DESCRIPTION
Hello! This issue came up while trying to copy objects.

I think there's an issue with the `getMetadata` function overwriting the object file instead of the md5 file. Adding the md5 extension as in this PR seemed to do the trick.

Please let me know if I can provide any more info! Thank you!