### PR TITLE
Website Routing Rules

### DIFF
--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -82,6 +82,46 @@ exports = module.exports = () =>
 
       const key = err.detail.Key;
 
+      if (config.routingRules) {
+        for (const { Condition, Redirect } of config.routingRules) {
+          let shouldRedirect = false;
+
+          if (
+            Condition.KeyPrefixEquals &&
+            Condition.HttpErrorCodeReturnedEquals
+          ) {
+            shouldRedirect =
+              key.startsWith(Condition.KeyPrefixEquals) &&
+              Condition.HttpErrorCodeReturnedEquals === 404 &&
+              err.code === "NoSuchKey";
+          } else if (Condition.KeyPrefixEquals) {
+            shouldRedirect = key.startsWith(Condition.KeyPrefixEquals);
+          } else if (Condition.HttpErrorCodeReturnedEquals) {
+            shouldRedirect =
+              Condition.HttpErrorCodeReturnedEquals === 404 &&
+              err.code === "NoSuchKey";
+          }
+
+          if (shouldRedirect) {
+            const redirectKey = Redirect.ReplaceKeyPrefixWith
+              ? key.replace(
+                  Condition.KeyPrefixEquals,
+                  Redirect.ReplaceKeyPrefixWith
+                )
+              : key;
+
+            if (Redirect.HttpRedirectCode) {
+              ctx.status = Redirect.HttpRedirectCode;
+            }
+
+            ctx.redirect(
+              `${Redirect.Protocol}://${Redirect.HostName}/${redirectKey}`
+            );
+            return;
+          }
+        }
+      }
+
       if (key === "" || key.endsWith("/")) {
         ctx.params = {
           ...ctx.params,

--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -83,40 +83,14 @@ exports = module.exports = () =>
       const key = err.detail.Key;
 
       if (config.routingRules) {
-        for (const { Condition, Redirect } of config.routingRules) {
-          let shouldRedirect = false;
-
-          if (
-            Condition.KeyPrefixEquals &&
-            Condition.HttpErrorCodeReturnedEquals
-          ) {
-            shouldRedirect =
-              key.startsWith(Condition.KeyPrefixEquals) &&
-              Condition.HttpErrorCodeReturnedEquals === 404 &&
-              err.code === "NoSuchKey";
-          } else if (Condition.KeyPrefixEquals) {
-            shouldRedirect = key.startsWith(Condition.KeyPrefixEquals);
-          } else if (Condition.HttpErrorCodeReturnedEquals) {
-            shouldRedirect =
-              Condition.HttpErrorCodeReturnedEquals === 404 &&
-              err.code === "NoSuchKey";
-          }
-
-          if (shouldRedirect) {
-            const redirectKey = Redirect.ReplaceKeyPrefixWith
-              ? key.replace(
-                  Condition.KeyPrefixEquals,
-                  Redirect.ReplaceKeyPrefixWith
-                )
-              : key;
-
-            if (Redirect.HttpRedirectCode) {
-              ctx.status = Redirect.HttpRedirectCode;
-            }
-
-            ctx.redirect(
-              `${Redirect.Protocol}://${Redirect.HostName}/${redirectKey}`
-            );
+        for (const routingRule of config.routingRules) {
+          let redirect = routingRule.evaluate(
+            key,
+            err.code === "NoSuchKey" ? 404 : undefined
+          );
+          if (redirect) {
+            ctx.status = redirect.statusCode;
+            ctx.redirect(redirect.location);
             return;
           }
         }

--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -84,6 +84,9 @@ exports = module.exports = () =>
 
       if (config.routingRules) {
         for (const routingRule of config.routingRules) {
+          // Only 404s are supported for RoutingRules right now, this may be a deviation from S3 behaviour but we don't
+          // have a reproduction of a scenario where S3 does a redirect on a status code other than 404. If you're
+          // reading this comment and you have a use-case, please raise an issue with details of your scenario. Thanks!
           if (routingRule.shouldRedirect(key, 404)) {
             const location = routingRule.getRedirectLocation(key, {
               protocol: ctx.protocol,

--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -85,7 +85,7 @@ exports = module.exports = () =>
       if (config.routingRules) {
         for (const routingRule of config.routingRules) {
           if (routingRule.shouldRedirect(key, 404)) {
-            const location = routingRule.getLocation(key, {
+            const location = routingRule.getRedirectLocation(key, {
               protocol: ctx.protocol,
               hostname: isVirtualHost
                 ? ctx.host

--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -84,12 +84,7 @@ exports = module.exports = () =>
 
       if (config.routingRules) {
         for (const routingRule of config.routingRules) {
-          if (
-            routingRule.shouldRedirect(
-              key,
-              err.code === "NoSuchKey" ? 404 : undefined
-            )
-          ) {
+          if (routingRule.shouldRedirect(key, 404)) {
             const location = routingRule.getLocation(key, {
               protocol: ctx.protocol,
               hostname: isVirtualHost

--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -84,13 +84,21 @@ exports = module.exports = () =>
 
       if (config.routingRules) {
         for (const routingRule of config.routingRules) {
-          let redirect = routingRule.evaluate(
-            key,
-            err.code === "NoSuchKey" ? 404 : undefined
-          );
-          if (redirect) {
-            ctx.status = redirect.statusCode;
-            ctx.redirect(redirect.location);
+          if (
+            routingRule.shouldRedirect(
+              key,
+              err.code === "NoSuchKey" ? 404 : undefined
+            )
+          ) {
+            const location = routingRule.getLocation(key, {
+              protocol: ctx.protocol,
+              hostname: isVirtualHost
+                ? ctx.host
+                : `${ctx.host}/${ctx.params.bucket}`
+            });
+
+            ctx.status = routingRule.statusCode;
+            ctx.redirect(location);
             return;
           }
         }

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -4,6 +4,7 @@ const xmlParser = require("fast-xml-parser");
 const { escapeRegExp } = require("lodash");
 
 const S3Error = require("./error");
+const RoutingRule = require("./routing-rule");
 
 exports.getConfigModel = function getConfigModel(type) {
   switch (type) {
@@ -287,11 +288,12 @@ class S3WebsiteConfiguration extends S3ConfigBase {
       }
     }
     if (WebsiteConfiguration.RoutingRules) {
-      this.routingRules = Array.isArray(
+      const routingRules = Array.isArray(
         WebsiteConfiguration.RoutingRules.RoutingRule
       )
         ? WebsiteConfiguration.RoutingRules.RoutingRule
         : [WebsiteConfiguration.RoutingRules.RoutingRule];
+      this.routingRules = routingRules.map(config => new RoutingRule(config));
     }
   }
 }

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -2,6 +2,7 @@
 
 const xmlParser = require("fast-xml-parser");
 const { escapeRegExp } = require("lodash");
+const he = require("he");
 
 const S3Error = require("./error");
 const RoutingRule = require("./routing-rule");
@@ -37,7 +38,8 @@ class S3ConfigBase {
     this.type = type;
     this.rawConfig = xmlParser.parse(config, {
       ignoreAttributes: false,
-      parseNodeValue: true
+      parseNodeValue: true,
+      tagValueProcessor: he.decode
     });
   }
 

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -252,27 +252,49 @@ class S3WebsiteConfiguration extends S3ConfigBase {
         );
       }
 
-      // TODO: needs length > 0
-
       const routingRules = Array.isArray(RoutingRules.RoutingRule)
         ? RoutingRules.RoutingRule
         : [RoutingRules.RoutingRule];
 
-      for (const RoutingRule of routingRules) {
-        if (RoutingRule.Condition) {
-          // TODO: KeyPrefixEquals required when HttpErrorCodeReturnedEquals is not specified
-          // TODO: HttpErrorCodeReturnedEquals required when KeyPrefixEquals is not specified
+      for (const { Condition, Redirect } of routingRules) {
+        if (
+          (Condition &&
+            !Condition.KeyPrefixEquals &&
+            !Condition.HttpErrorCodeReturnedEquals) ||
+          (!Redirect ||
+            (!Redirect.HostName &&
+              !Redirect.Protocol &&
+              !Redirect.ReplaceKeyPrefixWith &&
+              !Redirect.ReplaceKeyWith &&
+              !Redirect.HttpRedirectCode))
+        ) {
+          throw new S3Error(
+            "MalformedXML",
+            "The XML you provided was not well-formed or did not validate " +
+              "against our published schema"
+          );
         }
 
-        // TODO: Redirect required
-        // TODO: Redirect.Protocol not required if a sibling is present
-        // TODO: Redirect.Protocol one of http,https
-        // TODO: Redirect.HostName not required if a sibling is present
-        // TODO: Redirect.ReplaceKeyPrefixWith not required if a sibling is present
-        // TODO: Redirect.ReplaceKeyPrefixWith can be present only if ReplaceKeyWith is not provided
-        // TODO: Redirect.ReplaceKeyWith not required if one of the sibling is present
-        // TODO: Redirect.ReplaceKeyWIth can be present only if ReplaceKeyPrefixWith is not provided
-        // TODO: Redirect.HttpRedirectCode not required if one of the sibling is present
+        if (
+          Redirect.Protocol &&
+          (Redirect.Protocol !== "http" && Redirect.Protocol !== "https")
+        ) {
+          throw new S3Error(
+            "InvalidArgument",
+            "Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically.",
+            {
+              ArgumentName: "Protocol",
+              ArgumentValue: Redirect.Protocol
+            }
+          );
+        }
+
+        if (Redirect.ReplaceKeyWith && Redirect.ReplaceKeyPrefixWith) {
+          throw new S3Error(
+            "MalformedXML",
+            "You can only define ReplaceKeyPrefix or ReplaceKey but not both."
+          );
+        }
       }
     }
     return config;
@@ -287,7 +309,10 @@ class S3WebsiteConfiguration extends S3ConfigBase {
         this.errorDocumentKey = WebsiteConfiguration.ErrorDocument.Key;
       }
     }
-    if (WebsiteConfiguration.RoutingRules) {
+    if (
+      WebsiteConfiguration.RoutingRules &&
+      WebsiteConfiguration.RoutingRules.RoutingRule
+    ) {
       const routingRules = Array.isArray(
         WebsiteConfiguration.RoutingRules.RoutingRule
       )

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -278,6 +278,22 @@ class S3WebsiteConfiguration extends S3ConfigBase {
         }
 
         if (
+          Condition &&
+          Condition.HttpErrorCodeReturnedEquals &&
+          (Condition.HttpErrorCodeReturnedEquals < 400 ||
+            Condition.HttpErrorCodeReturnedEquals >= 600)
+        ) {
+          throw new S3Error(
+            "InvalidArgument",
+            `The provided HTTP error code (${Condition.HttpErrorCodeReturnedEquals}) is not valid. Valid codes are 4XX or 5XX.`,
+            {
+              ArgumentName: "HttpErrorCodeReturnedEquals",
+              ArgumentValue: Condition.HttpErrorCodeReturnedEquals
+            }
+          );
+        }
+
+        if (
           Redirect.Protocol &&
           (Redirect.Protocol !== "http" && Redirect.Protocol !== "https")
         ) {

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -34,7 +34,10 @@ class S3ConfigBase {
       throw new Error("Cannot create an instance of an abstract class");
     }
     this.type = type;
-    this.rawConfig = xmlParser.parse(config, { ignoreAttributes: false });
+    this.rawConfig = xmlParser.parse(config, {
+      ignoreAttributes: false,
+      parseNodeValue: true
+    });
   }
 
   toJSON() {
@@ -165,7 +168,8 @@ class S3WebsiteConfiguration extends S3ConfigBase {
     const {
       IndexDocument,
       ErrorDocument,
-      RedirectAllRequestsTo
+      RedirectAllRequestsTo,
+      RoutingRules
     } = WebsiteConfiguration;
     if (RedirectAllRequestsTo) {
       if (Array.isArray(RedirectAllRequestsTo)) {
@@ -238,6 +242,38 @@ class S3WebsiteConfiguration extends S3ConfigBase {
         ArgumentValue: IndexDocument.Suffix
       });
     }
+    if (RoutingRules) {
+      if (Array.isArray(RoutingRules) || !RoutingRules.RoutingRule) {
+        throw new S3Error(
+          "MalformedXML",
+          "The XML you provided was not well-formed or did not validate " +
+            "against our published schema"
+        );
+      }
+
+      // TODO: needs length > 0
+
+      const routingRules = Array.isArray(RoutingRules.RoutingRule)
+        ? RoutingRules.RoutingRule
+        : [RoutingRules.RoutingRule];
+
+      for (const RoutingRule of routingRules) {
+        if (RoutingRule.Condition) {
+          // TODO: KeyPrefixEquals required when HttpErrorCodeReturnedEquals is not specified
+          // TODO: HttpErrorCodeReturnedEquals required when KeyPrefixEquals is not specified
+        }
+
+        // TODO: Redirect required
+        // TODO: Redirect.Protocol not required if a sibling is present
+        // TODO: Redirect.Protocol one of http,https
+        // TODO: Redirect.HostName not required if a sibling is present
+        // TODO: Redirect.ReplaceKeyPrefixWith not required if a sibling is present
+        // TODO: Redirect.ReplaceKeyPrefixWith can be present only if ReplaceKeyWith is not provided
+        // TODO: Redirect.ReplaceKeyWith not required if one of the sibling is present
+        // TODO: Redirect.ReplaceKeyWIth can be present only if ReplaceKeyPrefixWith is not provided
+        // TODO: Redirect.HttpRedirectCode not required if one of the sibling is present
+      }
+    }
     return config;
   }
 
@@ -249,6 +285,13 @@ class S3WebsiteConfiguration extends S3ConfigBase {
       if (WebsiteConfiguration.ErrorDocument) {
         this.errorDocumentKey = WebsiteConfiguration.ErrorDocument.Key;
       }
+    }
+    if (WebsiteConfiguration.RoutingRules) {
+      this.routingRules = Array.isArray(
+        WebsiteConfiguration.RoutingRules.RoutingRule
+      )
+        ? WebsiteConfiguration.RoutingRules.RoutingRule
+        : [WebsiteConfiguration.RoutingRules.RoutingRule];
     }
   }
 }

--- a/lib/models/routing-rule.js
+++ b/lib/models/routing-rule.js
@@ -4,7 +4,7 @@ class RoutingRule {
   constructor(config) {
     this.condition = config.Condition;
     this.redirect = config.Redirect;
-    this.statusCode = (this.redirect && this.redirect.HttpRedirectCode) || 302;
+    this.statusCode = (this.redirect && this.redirect.HttpRedirectCode) || 301;
   }
 
   getLocation(key, defaults) {

--- a/lib/models/routing-rule.js
+++ b/lib/models/routing-rule.js
@@ -1,0 +1,60 @@
+"use strict";
+
+class RoutingRule {
+  constructor(config) {
+    this.condition = config.Condition;
+    this.redirect = config.Redirect;
+  }
+
+  evaluate(key, statusCode) {
+    if (!this.shouldRedirect(key, statusCode)) {
+      return null;
+    }
+
+    return {
+      statusCode: this.getStatusCode(),
+      location: this.getRedirectDestination(key)
+    };
+  }
+
+  getStatusCode() {
+    return this.redirect.HttpRedirectCode
+      ? this.redirect.HttpRedirectCode
+      : 302;
+  }
+
+  getRedirectDestination(key) {
+    const redirectKey = this.redirect.ReplaceKeyPrefixWith
+      ? key.replace(
+          this.condition.KeyPrefixEquals,
+          this.redirect.ReplaceKeyPrefixWith
+        )
+      : key;
+    const url = `${this.redirect.Protocol}://${this.redirect.HostName}/${redirectKey}`;
+    return url;
+  }
+
+  shouldRedirect(key, statusCode) {
+    if (
+      this.condition.KeyPrefixEquals &&
+      this.condition.HttpErrorCodeReturnedEquals
+    ) {
+      return (
+        key.startsWith(this.condition.KeyPrefixEquals) &&
+        this.condition.HttpErrorCodeReturnedEquals === statusCode
+      );
+    }
+
+    if (this.condition.KeyPrefixEquals) {
+      return key.startsWith(this.condition.KeyPrefixEquals);
+    }
+
+    if (this.condition.HttpErrorCodeReturnedEquals) {
+      return this.condition.HttpErrorCodeReturnedEquals === statusCode;
+    }
+
+    return false;
+  }
+}
+
+module.exports = RoutingRule;

--- a/lib/models/routing-rule.js
+++ b/lib/models/routing-rule.js
@@ -4,34 +4,31 @@ class RoutingRule {
   constructor(config) {
     this.condition = config.Condition;
     this.redirect = config.Redirect;
+    this.statusCode = (this.redirect && this.redirect.HttpRedirectCode) || 302;
   }
 
-  evaluate(key, statusCode) {
-    if (!this.shouldRedirect(key, statusCode)) {
-      return null;
+  getLocation(key, defaults) {
+    let redirectKey = key;
+
+    if (this.redirect.ReplaceKeyPrefixWith) {
+      if (!this.condition || !this.condition.KeyPrefixEquals) {
+        throw new Error(
+          "Cannot use ReplaceKeyPrefixWith without Condition.KeyPrefixEquals"
+        );
+      }
+
+      redirectKey = key.replace(
+        this.condition.KeyPrefixEquals,
+        this.redirect.ReplaceKeyPrefixWith
+      );
+    } else if (this.redirect.ReplaceKeyWith) {
+      redirectKey = this.redirect.ReplaceKeyWith;
     }
 
-    return {
-      statusCode: this.getStatusCode(),
-      location: this.getRedirectDestination(key)
-    };
-  }
+    const protocol = this.redirect.Protocol || defaults.protocol;
+    const hostName = this.redirect.HostName || defaults.hostname;
 
-  getStatusCode() {
-    return this.redirect.HttpRedirectCode
-      ? this.redirect.HttpRedirectCode
-      : 302;
-  }
-
-  getRedirectDestination(key) {
-    const redirectKey = this.redirect.ReplaceKeyPrefixWith
-      ? key.replace(
-          this.condition.KeyPrefixEquals,
-          this.redirect.ReplaceKeyPrefixWith
-        )
-      : key;
-    const url = `${this.redirect.Protocol}://${this.redirect.HostName}/${redirectKey}`;
-    return url;
+    return `${protocol}://${hostName}/${redirectKey}`;
   }
 
   shouldRedirect(key, statusCode) {

--- a/lib/models/routing-rule.js
+++ b/lib/models/routing-rule.js
@@ -7,7 +7,7 @@ class RoutingRule {
     this.statusCode = (this.redirect && this.redirect.HttpRedirectCode) || 301;
   }
 
-  getLocation(key, defaults) {
+  getRedirectLocation(key, defaults) {
     let redirectKey = key;
 
     if (this.redirect.ReplaceKeyPrefixWith) {

--- a/lib/models/routing-rule.js
+++ b/lib/models/routing-rule.js
@@ -11,14 +11,8 @@ class RoutingRule {
     let redirectKey = key;
 
     if (this.redirect.ReplaceKeyPrefixWith) {
-      if (!this.condition || !this.condition.KeyPrefixEquals) {
-        throw new Error(
-          "Cannot use ReplaceKeyPrefixWith without Condition.KeyPrefixEquals"
-        );
-      }
-
       redirectKey = key.replace(
-        this.condition.KeyPrefixEquals,
+        (this.condition && this.condition.KeyPrefixEquals) || /^/,
         this.redirect.ReplaceKeyPrefixWith
       );
     } else if (this.redirect.ReplaceKeyWith) {

--- a/lib/models/routing-rule.js
+++ b/lib/models/routing-rule.js
@@ -35,6 +35,10 @@ class RoutingRule {
   }
 
   shouldRedirect(key, statusCode) {
+    if (!this.condition) {
+      return true;
+    }
+
     if (
       this.condition.KeyPrefixEquals &&
       this.condition.HttpErrorCodeReturnedEquals

--- a/test/resources/website_test1.xml
+++ b/test/resources/website_test1.xml
@@ -5,13 +5,9 @@
     <RoutingRules>
         <RoutingRule>
             <Condition>
-                <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals>
                 <KeyPrefixEquals>test/</KeyPrefixEquals>
             </Condition>
             <Redirect>
-                <HostName>hostname</HostName>
-                <HttpRedirectCode>307</HttpRedirectCode>
-                <Protocol>http</Protocol>
                 <ReplaceKeyPrefixWith>replacement/</ReplaceKeyPrefixWith>
             </Redirect>
         </RoutingRule>

--- a/test/resources/website_test1.xml
+++ b/test/resources/website_test1.xml
@@ -1,0 +1,19 @@
+<WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals>
+                <KeyPrefixEquals>test/</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+                <HostName>hostname</HostName>
+                <HttpRedirectCode>307</HttpRedirectCode>
+                <Protocol>http</Protocol>
+                <ReplaceKeyPrefixWith>replacement/</ReplaceKeyPrefixWith>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>

--- a/test/resources/website_test2.xml
+++ b/test/resources/website_test2.xml
@@ -1,0 +1,27 @@
+<WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <KeyPrefixEquals>simple/</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+                <ReplaceKeyPrefixWith>replacement/</ReplaceKeyPrefixWith>
+            </Redirect>
+        </RoutingRule>
+        <RoutingRule>
+            <Condition>
+                <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals>
+                <KeyPrefixEquals>complex/</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+                <HostName>custom</HostName>
+                <HttpRedirectCode>307</HttpRedirectCode>
+                <Protocol>https</Protocol>
+                <ReplaceKeyWith>replacement</ReplaceKeyWith>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>

--- a/test/test.js
+++ b/test/test.js
@@ -3539,6 +3539,50 @@ describe("S3WebsiteConfiguration Tests", () => {
         ).to.throw(notWellFormedError);
       });
 
+      it("rejects when HttpErrorCodeReturnedEquals is not in range", () => {
+        expect(() =>
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <HttpErrorCodeReturnedEquals>304</HttpErrorCodeReturnedEquals>
+            </Condition>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>`)
+        ).to.throw(
+          "The provided HTTP error code (304) is not valid. Valid codes are 4XX or 5XX."
+        );
+
+        expect(() =>
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <HttpErrorCodeReturnedEquals>600</HttpErrorCodeReturnedEquals>
+            </Condition>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>`)
+        ).to.throw(
+          "The provided HTTP error code (600) is not valid. Valid codes are 4XX or 5XX."
+        );
+      });
+
       it("accepts a Condition with a KeyPrefixEquals element", () => {
         expect(
           S3WebsiteConfiguration.validate(`

--- a/test/test.js
+++ b/test/test.js
@@ -3445,8 +3445,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
       ).to.throw(notWellFormedError);
     });
 
@@ -3460,8 +3459,7 @@ describe("S3WebsiteConfiguration Tests", () => {
     <RoutingRules>
         <other />
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
       ).to.throw(notWellFormedError);
     });
 
@@ -3479,8 +3477,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
       ).to.exist;
     });
 
@@ -3503,8 +3500,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
       ).to.exist;
     });
 
@@ -3526,8 +3522,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.throw(notWellFormedError);
       });
 
@@ -3548,8 +3543,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.exist;
       });
 
@@ -3570,8 +3564,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.exist;
       });
 
@@ -3589,8 +3582,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.exist;
       });
     });
@@ -3610,8 +3602,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Condition>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.throw(notWellFormedError);
       });
 
@@ -3632,8 +3623,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.throw(notWellFormedError);
       });
 
@@ -3654,8 +3644,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.throw(
           "Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically."
         );
@@ -3675,8 +3664,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.exist;
       });
 
@@ -3719,8 +3707,7 @@ describe("S3WebsiteConfiguration Tests", () => {
             </Redirect>
         </RoutingRule>
     </RoutingRules>
-</WebsiteConfiguration>
-      `)
+</WebsiteConfiguration>`)
         ).to.throw(
           "You can only define ReplaceKeyPrefix or ReplaceKey but not both."
         );

--- a/test/test.js
+++ b/test/test.js
@@ -3338,7 +3338,7 @@ describe("Routing Rule Tests", () => {
       });
 
       expect(rule.statusCode).to.equal(301);
-      expect(rule.getLocation("key", defaults)).to.equal(
+      expect(rule.getRedirectLocation("key", defaults)).to.equal(
         "https://localhost/key"
       );
     });
@@ -3351,7 +3351,7 @@ describe("Routing Rule Tests", () => {
       });
 
       expect(rule.statusCode).to.equal(307);
-      expect(rule.getLocation("key", defaults)).to.equal(
+      expect(rule.getRedirectLocation("key", defaults)).to.equal(
         "https://example.com/key"
       );
     });
@@ -3364,7 +3364,7 @@ describe("Routing Rule Tests", () => {
       });
 
       expect(rule.statusCode).to.equal(301);
-      expect(rule.getLocation("key", defaults)).to.equal(
+      expect(rule.getRedirectLocation("key", defaults)).to.equal(
         "http://example.com/key"
       );
     });
@@ -3380,7 +3380,7 @@ describe("Routing Rule Tests", () => {
       });
 
       expect(rule.statusCode).to.equal(301);
-      expect(rule.getLocation("prefix/key", defaults)).to.equal(
+      expect(rule.getRedirectLocation("prefix/key", defaults)).to.equal(
         "https://example.com/replacement/key"
       );
     });
@@ -3393,7 +3393,7 @@ describe("Routing Rule Tests", () => {
       });
 
       expect(rule.statusCode).to.equal(301);
-      expect(rule.getLocation("key", defaults)).to.equal(
+      expect(rule.getRedirectLocation("key", defaults)).to.equal(
         "https://example.com/replacement"
       );
     });
@@ -3412,7 +3412,7 @@ describe("Routing Rule Tests", () => {
       });
 
       expect(rule.statusCode).to.equal(307);
-      expect(rule.getLocation("prefix/key", defaults)).to.equal(
+      expect(rule.getRedirectLocation("prefix/key", defaults)).to.equal(
         "http://localhost/replacement/key"
       );
     });

--- a/test/test.js
+++ b/test/test.js
@@ -3385,6 +3385,19 @@ describe("Routing Rule Tests", () => {
       );
     });
 
+    it("should replace blank prefix with ReplaceKeyPrefixWith", () => {
+      const rule = new RoutingRule({
+        Redirect: {
+          ReplaceKeyPrefixWith: "replacement/"
+        }
+      });
+
+      expect(rule.statusCode).to.equal(301);
+      expect(rule.getRedirectLocation("prefix/key", defaults)).to.equal(
+        "https://example.com/replacement/prefix/key"
+      );
+    });
+
     it("should redirect using only ReplaceKeyWith", () => {
       const rule = new RoutingRule({
         Redirect: {

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ const { URL } = require("url");
 const S3rver = require("..");
 const { toISO8601String } = require("../lib/utils");
 const RoutingRule = require("../lib/models/routing-rule");
+const { S3WebsiteConfiguration } = require("../lib/models/config");
 
 const { expect } = chai;
 chai.use(chaiAsPromised);
@@ -3414,6 +3415,295 @@ describe("Routing Rule Tests", () => {
       expect(rule.getLocation("prefix/key", defaults)).to.equal(
         "http://localhost/replacement/key"
       );
+    });
+  });
+});
+
+describe("S3WebsiteConfiguration Tests", () => {
+  const notWellFormedError =
+    "The XML you provided was not well-formed or did not validate against our published schema";
+
+  describe("RoutingRules", () => {
+    it("rejects when multiple RoutingRules elements exist", () => {
+      expect(() =>
+        S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+    <RoutingRules>
+        <RoutingRule>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+      ).to.throw(notWellFormedError);
+    });
+
+    it("rejects when no RoutingRules.RoutingRule elements exist", () => {
+      expect(() =>
+        S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <other />
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+      ).to.throw(notWellFormedError);
+    });
+
+    it("accepts single RoutingRules.RoutingRule", () => {
+      expect(
+        S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+      ).to.exist;
+    });
+
+    it("accepts multiple RoutingRules.RoutingRule", () => {
+      expect(
+        S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+        <RoutingRule>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+      ).to.exist;
+    });
+
+    describe("Condition", () => {
+      it("rejects when no KeyPrefixEquals or HttpErrorCodeReturnedEquals elements exist", () => {
+        expect(() =>
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <other />
+            </Condition>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.throw(notWellFormedError);
+      });
+
+      it("accepts a Condition with a KeyPrefixEquals element", () => {
+        expect(
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <KeyPrefixEquals>test</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.exist;
+      });
+
+      it("accepts a Condition with a HttpErrorCodeReturnedEquals element", () => {
+        expect(
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals>
+            </Condition>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.exist;
+      });
+
+      it("accepts a config with no Condition", () => {
+        expect(
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.exist;
+      });
+    });
+
+    describe("Redirect", () => {
+      it("rejects when Redirect doesn't exist", () => {
+        expect(() =>
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <KeyPrefixEquals>test</KeyPrefixEquals>
+            </Condition>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.throw(notWellFormedError);
+      });
+
+      it("rejects when no valid Redirect options exist", () => {
+        expect(() =>
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <KeyPrefixEquals>test</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+                <other />
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.throw(notWellFormedError);
+      });
+
+      it("rejects when Protocol isn't http or https", () => {
+        expect(() =>
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <KeyPrefixEquals>test</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+                <Protocol>ftp</Protocol>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.throw(
+          "Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically."
+        );
+      });
+
+      it("accepts a valid Redirect config", () => {
+        expect(
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Redirect>
+                <HostName>example.com</HostName>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.exist;
+      });
+
+      it("rejects a Redirect config with both ReplaceKeyWith and ReplaceKeyPrefixWith elements", () => {
+        expect(() =>
+          S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+    <IndexDocument>
+        <Suffix>index.html</Suffix>
+    </IndexDocument>
+    <RoutingRules>
+        <RoutingRule>
+            <Condition>
+                <KeyPrefixEquals>test</KeyPrefixEquals>
+            </Condition>
+            <Redirect>
+                <ReplaceKeyWith>foo</ReplaceKeyWith>
+                <ReplaceKeyPrefixWith>bar</ReplaceKeyPrefixWith>
+            </Redirect>
+        </RoutingRule>
+    </RoutingRules>
+</WebsiteConfiguration>
+      `)
+        ).to.throw(
+          "You can only define ReplaceKeyPrefix or ReplaceKey but not both."
+        );
+      });
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -3208,6 +3208,16 @@ describe("Routing Rule Tests", () => {
     const matchingStatusCode = 404;
     const nonMatchStatusCode = 200;
 
+    it("evaluates with no condition", () => {
+      const rule = new RoutingRule({
+        Redirect: {
+          HostName: "localhost"
+        }
+      });
+
+      expect(rule.evaluate("key", 200)).to.exist;
+    });
+
     it("evaluates only KeyPrefixEquals", () => {
       const rule = new RoutingRule({
         Condition: {

--- a/test/test.js
+++ b/test/test.js
@@ -3198,7 +3198,7 @@ describe("Static Website Tests", function() {
         await server.close();
       }
       expect(error).to.exist;
-      expect(error.statusCode).to.equal(302);
+      expect(error.statusCode).to.equal(301);
       expect(error.response.headers).to.have.property(
         "location",
         "http://localhost:4569/site/replacement/key"
@@ -3231,7 +3231,7 @@ describe("Static Website Tests", function() {
         await server.close();
       }
       expect(error).to.exist;
-      expect(error.statusCode).to.equal(302);
+      expect(error.statusCode).to.equal(301);
       expect(error.response.headers).to.have.property(
         "location",
         "http://localhost:4569/site/replacement/key"
@@ -3336,7 +3336,7 @@ describe("Routing Rule Tests", () => {
         }
       });
 
-      expect(rule.statusCode).to.equal(302);
+      expect(rule.statusCode).to.equal(301);
       expect(rule.getLocation("key", defaults)).to.equal(
         "https://localhost/key"
       );
@@ -3362,7 +3362,7 @@ describe("Routing Rule Tests", () => {
         }
       });
 
-      expect(rule.statusCode).to.equal(302);
+      expect(rule.statusCode).to.equal(301);
       expect(rule.getLocation("key", defaults)).to.equal(
         "http://example.com/key"
       );
@@ -3378,7 +3378,7 @@ describe("Routing Rule Tests", () => {
         }
       });
 
-      expect(rule.statusCode).to.equal(302);
+      expect(rule.statusCode).to.equal(301);
       expect(rule.getLocation("prefix/key", defaults)).to.equal(
         "https://example.com/replacement/key"
       );
@@ -3391,7 +3391,7 @@ describe("Routing Rule Tests", () => {
         }
       });
 
-      expect(rule.statusCode).to.equal(302);
+      expect(rule.statusCode).to.equal(301);
       expect(rule.getLocation("key", defaults)).to.equal(
         "https://example.com/replacement"
       );

--- a/test/test.js
+++ b/test/test.js
@@ -3680,6 +3680,27 @@ describe("S3WebsiteConfiguration Tests", () => {
         ).to.exist;
       });
 
+      it("parses values with XML encoding", () => {
+        const config = S3WebsiteConfiguration.validate(`
+<WebsiteConfiguration>
+  <IndexDocument>
+      <Suffix>index.html</Suffix>
+  </IndexDocument>
+  <RoutingRules>
+      <RoutingRule>
+          <Redirect>
+              <ReplaceKeyPrefixWith>url?test=1&amp;key=</ReplaceKeyPrefixWith>
+          </Redirect>
+      </RoutingRule>
+  </RoutingRules>
+</WebsiteConfiguration>
+    `);
+
+        expect(config.routingRules[0].redirect.ReplaceKeyPrefixWith).to.equal(
+          "url?test=1&key="
+        );
+      });
+
       it("rejects a Redirect config with both ReplaceKeyWith and ReplaceKeyPrefixWith elements", () => {
         expect(() =>
           S3WebsiteConfiguration.validate(`


### PR DESCRIPTION
Hey, I need support for routing rules for my setup so I figured I'd give it a shot at implementing them. This is a work in progress, but I figured I'd open the PR early.

The example I have implemented so far is what I personally need, but it isn't the simplest scenario. I wanted to prove out that I could get this working for my case before implementing anything else. I only have one test at the moment, but I'll expand them as I go.

Any feedback is welcome. I'll update this PR as I progress.

## TODO

  - [x] Rules with no Condition
  - [x] `KeyPrefixEquals` only conditional
  - [x] `HttpErrorCodeReturnedEquals` only conditional
  - [x] `KeyPrefixEquals` and `HttpErrorCodeReturnedEquals` conditonal
  - [x] Redirect with default hostname
  - [x] Redirect with custom hostname from `HostName` value
  - [x] Redirect with default protocol
  - [x] Redirect with protocol from `Protocol` value
  - [x] Redirect with key prefix replaced by `ReplaceKeyPrefixWith` value
  - [x] Redirect with key replaced by `ReplaceKeyWith` value
  - [x] Redirect with custom response code specified with `HttpRedirectCode`
  - [x] Redirect with default status code *302? test what S3 does*
  - [x] Validation of config
  - [ ] ~`HttpErrorCodeReturnedEquals` for a non-404 status code~
