### PR TITLE
fixes breaking api change in fast-xml parser

### DIFF
--- a/lib/models/error.js
+++ b/lib/models/error.js
@@ -33,7 +33,7 @@ class S3Error extends Error {
 
   toXML() {
     const parser = new j2xParser({
-      tagValueProcessor: a => he.encode(a, { useNamedReferences: true })
+      tagValueProcessor: a => he.encode(''+ a, { useNamedReferences: true })
     });
     return [
       '<?xml version="1.0" encoding="UTF-8"?>',

--- a/lib/models/error.js
+++ b/lib/models/error.js
@@ -33,7 +33,7 @@ class S3Error extends Error {
 
   toXML() {
     const parser = new j2xParser({
-      tagValueProcessor: a => he.encode(''+ a, { useNamedReferences: true })
+      tagValueProcessor: a => he.encode("" + a, { useNamedReferences: true })
     });
     return [
       '<?xml version="1.0" encoding="UTF-8"?>',

--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -45,7 +45,7 @@ class S3rver extends Koa {
       const parser = new xmlParser.j2xParser({
         ignoreAttributes: false,
         attrNodeName: "@",
-        tagValueProcessor: a => he.encode('' + a, { useNamedReferences: true })
+        tagValueProcessor: a => he.encode("" + a, { useNamedReferences: true })
       });
       this.use(async (ctx, next) => {
         await next();

--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -45,7 +45,7 @@ class S3rver extends Koa {
       const parser = new xmlParser.j2xParser({
         ignoreAttributes: false,
         attrNodeName: "@",
-        tagValueProcessor: a => he.encode(a, { useNamedReferences: true })
+        tagValueProcessor: a => he.encode('' + a, { useNamedReferences: true })
       });
       this.use(async (ctx, next) => {
         await next();


### PR DESCRIPTION
https://github.com/NaturalIntelligence/fast-xml-parser/commit/3cb3e30ff1c18729429691469420f45ed15561cc makes a change to the api for tagValueProcessor meaning that we have to make sure the callback argument is a string. 