### PR TITLE
Fix calling HEAD on an empty object

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -243,7 +243,7 @@ class FilesystemStore {
   async getObject(bucket, key, options) {
     try {
       const metadata = await this.getMetadata(bucket, key);
-      const lastByte = Number(metadata["content-length"]) - 1;
+      const lastByte = Math.max(0, Number(metadata["content-length"]) - 1);
       const range = {
         start: (options && options.start) || 0,
         end: Math.min((options && options.end) || Infinity, lastByte)

--- a/test/test.js
+++ b/test/test.js
@@ -748,6 +748,20 @@ describe("S3rver Tests", function() {
     expect(object.ContentType).to.equal("image/jpeg");
   });
 
+  it("should HEAD an empty object in a bucket", async function() {
+    await s3Client
+      .putObject({
+        Bucket: buckets[0].name,
+        Key: "somekey",
+        Body: ""
+      })
+      .promise();
+    const object = await s3Client
+      .headObject({ Bucket: buckets[0].name, Key: "somekey" })
+      .promise();
+    expect(object.ETag).to.match(/"[a-fA-F0-9]{32}"/);
+  });
+
   it("should get partial image from a bucket with a range request", async function() {
     const file = path.join(__dirname, "resources/image0.jpg");
     await s3Client


### PR DESCRIPTION
Closes #484. This was a very subtle bug, caused by the fact that the last byte of an empty object "begins" at offset -1. This can be worked around by just ensuring the last byte is nonnegative.