### PR TITLE
fix #504, as reponse can both be XML and HMTL documents, we use he.es…

### DIFF
--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -45,8 +45,7 @@ class S3rver extends Koa {
       const parser = new xmlParser.j2xParser({
         ignoreAttributes: false,
         attrNodeName: '@',
-        tagValueProcessor: a =>
-          he.encode(a.toString(), { useNamedReferences: true }),
+        tagValueProcessor: a => he.escape(a.toString()),
       });
       this.use(async (ctx, next) => {
         await next();


### PR DESCRIPTION
…cape instead of he.encode

as he.escape will produce valid XML while he.encode produce also html entities not known by pure XML