### PR TITLE
Support declaring custom service endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,18 +105,19 @@ You can also run s3rver programmatically.
 Creates a S3rver instance
 
 <!-- prettier-ignore-start -->
-| Option                         | Type                 | Default     | Description
-| ------------------------------ | -------------------- | ----------- | -----------
-| address                        | `string`             | `localhost` | Host/IP to bind to
-| port                           | `number`             | `4568`      | Port of the HTTP server
-| key                            | `string` \| `Buffer` |             | Private key for running with TLS
-| cert                           | `string` \| `Buffer` |             | Certificate for running with TLS
-| silent                         | `boolean`            | `false`     | Suppress log messages
-| directory                      | `string`             |             | Data directory
-| resetOnClose                   | `boolean`            | `false`     | Remove all bucket data on server close
-| allowMismatchedSignatures      | `boolean`            | `false`     | Prevent `SignatureDoesNotMatch` errors for all well-formed signatures
-| configureBuckets\[].name       | `string`             |             | The name of a prefabricated bucket to create when the server starts
-| configureBuckets\[].configs\[] | `string` \| `Buffer` |             | Raw XML string or Buffer of Bucket config
+| Option                         | Type                 | Default         | Description
+| ------------------------------ | -------------------- | --------------- | -----------
+| address                        | `string`             | `localhost`     | Host/IP to bind to
+| port                           | `number`             | `4568`          | Port of the HTTP server
+| key                            | `string` \| `Buffer` |                 | Private key for running with TLS
+| cert                           | `string` \| `Buffer` |                 | Certificate for running with TLS
+| silent                         | `boolean`            | `false`         | Suppress log messages
+| serviceEndpoint                | `string`             | `amazonaws.com` | For self-hosted setups where S3rver should override the AWS S3 endpoint
+| directory                      | `string`             |                 | Data directory
+| resetOnClose                   | `boolean`            | `false`         | Remove all bucket data on server close
+| allowMismatchedSignatures      | `boolean`            | `false`         | Prevent `SignatureDoesNotMatch` errors for all well-formed signatures
+| configureBuckets\[].name       | `string`             |                 | The name of a prefabricated bucket to create when the server starts
+| configureBuckets\[].configs\[] | `string` \| `Buffer` |                 | Raw XML string or Buffer of Bucket config
 <!-- prettier-ignore-end -->
 
 For your convenience, we've provided sample bucket configurations you can access using `require.resolve`:

--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -60,6 +60,11 @@ program
     fs.readFileSync,
   )
   .option(
+    '--service-endpoint <address>',
+    'Overrides the AWS S3 service endpoint',
+    S3rver.defaultOptions.serviceEndpoint,
+  )
+  .option(
     '--allow-mismatched-signatures',
     'Prevent SignatureDoesNotMatch errors for all well-formed signatures',
   )

--- a/lib/controllers/bucket.js
+++ b/lib/controllers/bucket.js
@@ -215,7 +215,7 @@ exports.getBucket = async function getBucket(ctx) {
       break;
   }
   ctx.logger.info(
-    'Fetched bucket "%s" with options %s',
+    'Fetched bucket "%s" with options %j',
     ctx.params.bucket,
     options,
   );

--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -1,27 +1,40 @@
 'use strict';
 
-const net = require('net');
+const { escapeRegExp } = require('lodash');
+const { isIP } = require('net');
 
 /**
  * Middleware that rewrites URLs for buckets specified via subdomain or host header
  */
 module.exports = () =>
   function vhost(ctx, next) {
-    const [match, bucket] =
-      /^(?:(.+))?\.s3(-website)?([-.].+)?\.amazonaws\.com$/.exec(
-        ctx.hostname,
-      ) || [];
-
+    // prettier-ignore
+    const pattern = RegExp(`^(?:(.+)\\.)?s3(-website)?([-.].+)?\\.${escapeRegExp(ctx.app.serviceEndpoint)}$`);
+    const [match, bucket, website] = pattern.exec(ctx.hostname) || [];
+    ctx.state.vhost = Boolean(bucket);
     if (match) {
-      // Handle requests for <bucket>.s3[-website][-<region>].amazonaws.com, if they arrive.
+      ctx.state.service = website ? 's3-website' : 's3';
       if (bucket) {
+        // Rewrite path for requests to <bucket>.s3[-website][-<region>].amazonaws.com
         ctx.path = `/${bucket}${ctx.path}`;
       }
-    } else if (!net.isIP(ctx.hostname) && ctx.hostname !== 'localhost') {
-      ctx.state.vhost = true;
-      // otherwise attempt to distinguish virtual host-style requests
-      ctx.path = `/${ctx.hostname}${ctx.path}`;
+    } else {
+      // if the request contains any x-amz-* headers or query string parameters,
+      // consider this an SDK/CLI request
+      for (const key of [
+        ...Object.keys(ctx.headers),
+        ...Object.keys(ctx.query),
+      ]) {
+        if (key.toLowerCase().startsWith('x-amz-')) {
+          ctx.state.service = 's3';
+          break;
+        }
+      }
+      if (!isIP(ctx.hostname) && ctx.hostname !== 'localhost') {
+        ctx.state.vhost = true;
+        // otherwise attempt to distinguish virtual host-style requests
+        ctx.path = `/${ctx.hostname}${ctx.path}`;
+      }
     }
-
     return next();
   };

--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -33,37 +33,34 @@ exports = module.exports = () =>
       undefined,
       'website',
     );
-    let isVirtualHost;
-    if (ctx.hostname.match(/\.s3-website[-.].+\.amazonaws\.com$/)) {
-      isVirtualHost = true;
-    } else if (
-      ctx.hostname.match(/(^|\.)s3([-.].+)?\.amazonaws\.com$/) ||
-      !ctx.params.bucket ||
-      !config
-    ) {
+    if (ctx.state.service === 's3' || (!ctx.state.service && !config)) {
       // requests to the the API endpoint use normal output behavior
       // (vhost-style buckets without website configurations also always use this behavior)
       return next();
     }
 
-    // if the request contains any x-amz-* headers or query string parameters, consider
-    // this an SDK/CLI request and don't handle it with the website middleware
-    for (const key of [...Object.keys(ctx.header), ...Object.keys(ctx.query)]) {
-      if (key.toLowerCase().startsWith('x-amz-')) {
-        return next();
-      }
-    }
-
     ctx.onerror = onerror;
     ctx.state.website = config || {};
 
-    if (isVirtualHost && !config) {
-      // throw website-specific errors for requests to a .s3-website-<region>.amazonaws.com vhost
-      throw new S3Error(
-        'NoSuchWebsiteConfiguration',
-        'The specified bucket does not have a website configuration',
-        { BucketName: ctx.params.bucket },
-      );
+    // throw website-specific errors for requests to a .s3-website vhost
+    if (ctx.state.service === 's3-website') {
+      // disallow x-amz-* query params for website requests
+      for (const key of Object.keys(ctx.query)) {
+        if (key.toLowerCase().startsWith('x-amz-')) {
+          throw new S3Error(
+            'UnsupportedQuery',
+            'The request contained an unsupported query string parameter.',
+            { ParameterName: key },
+          );
+        }
+      }
+      if (!config) {
+        throw new S3Error(
+          'NoSuchWebsiteConfiguration',
+          'The specified bucket does not have a website configuration',
+          { BucketName: ctx.params.bucket },
+        );
+      }
     }
 
     try {
@@ -84,7 +81,7 @@ exports = module.exports = () =>
           if (routingRule.shouldRedirect(key, 404)) {
             const location = routingRule.getRedirectLocation(key, {
               protocol: ctx.protocol,
-              hostname: isVirtualHost
+              hostname: ctx.state.vhost
                 ? ctx.host
                 : `${ctx.host}/${ctx.params.bucket}`,
             });
@@ -112,7 +109,7 @@ exports = module.exports = () =>
           err.detail.Key = `${key}/${config.indexDocumentSuffix}`;
           throw err;
         }
-        if (isVirtualHost) {
+        if (ctx.state.vhost) {
           ctx.redirect(`/${key}/`);
         } else {
           // This isn't possible on real S3, but for convenience this allows website

--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -24,6 +24,7 @@ class S3rver extends Koa {
     this.context.onerror = onerror;
     const {
       silent,
+      serviceEndpoint,
       directory,
       resetOnClose,
       allowMismatchedSignatures,
@@ -33,6 +34,7 @@ class S3rver extends Koa {
     this.serverOptions = serverOptions;
     this._configureBuckets = configureBuckets;
     this.silent = silent;
+    this.serviceEndpoint = serviceEndpoint;
     this.resetOnClose = resetOnClose;
     this.allowMismatchedSignatures = allowMismatchedSignatures;
     this.store = this.context.store = new FilesystemStore(directory);
@@ -208,6 +210,7 @@ S3rver.defaultOptions = {
   key: undefined,
   cert: undefined,
   silent: false,
+  serviceEndpoint: 'amazonaws.com',
   directory: path.join(os.tmpdir(), 's3rver'),
   resetOnClose: false,
   allowMismatchedSignatures: false,


### PR DESCRIPTION
Resolves #487. This is for advanced use-cases where the entire S3 service endpoint is self-hosted with a real domain name. By default, S3rver will assume a default service endpoint of `amazonaws.com`, and it can be overridden by declaring `serviceEndpoint: 'my-domain.com'` in S3rver's class constructor.

This PR also consolidates all hostname parsing to vhost.js so that any middleware that alters its behavior based on the format of the hostname can refer to `ctx.state.vhost` and `ctx.state.service` and avoid parsing the hostname again.