### PR TITLE
URL encode the uri part of the stringToSign

### DIFF
--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -466,7 +466,7 @@ function getStringToSign(canonicalRequest) {
     ...canonicalRequest.amzHeaders,
     canonicalRequest.querystring
       ? `${canonicalRequest.uri}?${canonicalRequest.querystring}`
-      : canonicalRequest.uri,
+      : encodeURI(canonicalRequest.uri),
   ].join('\n');
 }
 


### PR DESCRIPTION
Fix #513

Tested locally. Now we are able to verify signature coming from Python boto with non ascii character (such a "é").