### PR TITLE
Adds support for 'ObjectCreated:Post' when receiving an object via Presigned POST

### DIFF
--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -286,13 +286,13 @@ exports.postObject = async function postObject(ctx) {
       fields,
     );
 
-    const md5Hash = await ctx.store.postObject(object);
+    const { size, md5 } = await ctx.store.postObject(object);
 
     ctx.type = 'application/xml';
     ctx.status = 201;
     ctx.body = {
       PostResponse: {
-        Etag: md5Hash,
+        Etag: md5,
         Bucket: ctx.params.bucket,
         Key: object.key,
         Location: ctx.href.split('?')[0] + '/' + object.key,
@@ -304,6 +304,15 @@ exports.postObject = async function postObject(ctx) {
       object.key,
       object.bucket,
     );
+
+    triggerS3Event(ctx, {
+      bucket: ctx.params.bucket,
+      eventType: 'Post',
+      S3Item: new S3Object(object.bucket, object.key, null, {
+        etag: JSON.stringify(md5),
+        'content-length': size,
+      }),
+    });
   } catch (err) {
     ctx.logger.error(
       'Error uploading object to bucket "%s"',

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -288,7 +288,7 @@ class FilesystemStore {
     await fs.unlink(object.content.path);
 
     const md5 = md5File.sync(objectPath);
-    const { size } = fs.statSync(objectPath);
+    const { size } = await fs.stat(objectPath);
     await this.putMetadata(object.bucket, object.key, object.metadata, md5);
     return { size, md5 };
   }

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -288,8 +288,9 @@ class FilesystemStore {
     await fs.unlink(object.content.path);
 
     const md5 = md5File.sync(objectPath);
+    const { size } = fs.statSync(objectPath);
     await this.putMetadata(object.bucket, object.key, object.metadata, md5);
-    return md5;
+    return { size, md5 };
   }
 
   async putObject(object) {

--- a/test/test.js
+++ b/test/test.js
@@ -2275,8 +2275,10 @@ describe('S3 Event Notification Tests', function() {
     const eventPromise = fromEvent(server, 'event')
       .pipe(take(1))
       .toPromise();
-    const { url, fields } = await s3Client
-      .createPresignedPost({ Bucket: buckets[0].name, Fields: { key: 'testPostKey' } });
+    const { url, fields } = await s3Client.createPresignedPost({
+      Bucket: buckets[0].name,
+      Fields: { key: 'testPostKey' },
+    });
     await request({
       method: 'POST',
       uri: url,


### PR DESCRIPTION
Adds an `ObjectCreated:Post` event when a `POST` request is made.

Fixes an issue I created https://github.com/jamhall/s3rver/issues/529