### PR TITLE
Make walk over dir tree async

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -13,6 +13,7 @@ const S3Object = require('../models/object');
 const { concatStreams, walk } = require('../utils');
 
 const S3RVER_SUFFIX = '%s._S3rver_%s';
+const STOP_ITERATION = 'STOP_ITERATION';
 
 class FilesystemStore {
   static decodeKeyPath(keyPath) {
@@ -182,9 +183,10 @@ class FilesystemStore {
     const objectSuffix = format(S3RVER_SUFFIX, '', 'object');
     const keys = [];
     let isTruncated = false;
-    for (const keyPath of it) {
+    await it(keyPath => {
+      // for (const keyPath of it) {
       if (!keyPath.endsWith(objectSuffix)) {
-        continue;
+        return;
       }
 
       const key = FilesystemStore.decodeKeyPath(
@@ -192,7 +194,7 @@ class FilesystemStore {
       );
 
       if (key <= startAfter || !key.startsWith(prefix)) {
-        continue;
+        return;
       }
 
       if (delimiter) {
@@ -200,7 +202,7 @@ class FilesystemStore {
         if (idx !== -1) {
           // add to common prefixes before filtering this key out
           commonPrefixes.add(key.slice(0, prefix.length + idx + 1));
-          continue;
+          return;
         }
       }
 
@@ -208,9 +210,11 @@ class FilesystemStore {
         keys.push(key);
       } else {
         isTruncated = true;
-        break;
+        throw STOP_ITERATION;
       }
-    }
+    }).catch(err => {
+      if (err !== STOP_ITERATION) throw err;
+    });
 
     const metadataArr = await Promise.all(
       keys.map(key =>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,17 +6,23 @@ const fs = require('fs-extra');
 const path = require('path');
 const { PassThrough } = require('stream');
 
-exports.walk = function* walk(dir, recurseFilter) {
-  for (const filename of fs.readdirSync(dir)) {
-    const filePath = path.posix.join(dir, filename);
-    const stats = fs.statSync(filePath);
-    if (!stats.isDirectory()) {
-      yield filePath;
-    } else if (!recurseFilter || recurseFilter(filePath)) {
-      yield* walk(filePath, recurseFilter);
-    }
-  }
-};
+exports.walk = (dir, recurseFilter) => each =>
+  fs.readdir(dir).then(files =>
+    files.reduce(
+      (previousPromise, filename) =>
+        previousPromise.then(() => {
+          const filePath = path.posix.join(dir, filename);
+          return fs.stat(filePath).then(stats => {
+            if (!stats.isDirectory()) {
+              return each(filePath);
+            } else if (!recurseFilter || recurseFilter(filePath)) {
+              return exports.walk(filePath, recurseFilter)(each);
+            }
+          });
+        }),
+      Promise.resolve(),
+    ),
+  );
 
 exports.capitalizeHeader = function(header) {
   const exceptions = {


### PR DESCRIPTION
In the case of NodeJS 10 the change could be limited to adding "async", "await" and removing "Sync" in appropriate places. However, the project accepts Node 8 compliance, so it proposes this approach.

The function is used in a fairly critical place and is recursive - file listing in bucket, so it can potentially be called frequently.