### PR TITLE
Use transform & pipe to manage streams

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -2,6 +2,7 @@
 
 const crypto = require('crypto');
 const fs = require('fs-extra');
+const { Transform } = require('stream');
 const { pick, pickBy, sortBy, zip } = require('lodash');
 const path = require('path');
 const { format } = require('util');
@@ -295,16 +296,18 @@ class FilesystemStore {
       } else {
         let totalLength = 0;
         object.content
-          .on('data', chunk => {
-            writeStream.write(chunk, 'binary');
-            md5Context.update(chunk, 'binary');
-            totalLength += chunk.length;
-          })
+          .pipe(
+            new Transform({
+              transform(chunk, encoding, callback) {
+                md5Context.update(chunk, encoding);
+                totalLength += chunk.length;
+                callback(null, chunk);
+              },
+            }),
+          )
           .on('error', reject)
-          .on('end', () => {
-            writeStream.end();
-            resolve([totalLength, md5Context.digest('hex')]);
-          });
+          .on('finish', () => resolve([totalLength, md5Context.digest('hex')]))
+          .pipe(writeStream);
       }
     });
     await this.putMetadata(object.bucket, object.key, object.metadata, md5);
@@ -401,16 +404,20 @@ class FilesystemStore {
       let totalLength = 0;
 
       content
-        .on('data', chunk => {
-          writeStream.write(chunk, 'binary');
-          md5Context.update(chunk, 'binary');
-          totalLength += chunk.length;
-        })
+        .pipe(
+          new Transform({
+            transform(chunk, encoding, callback) {
+              md5Context.update(chunk, 'binary');
+              totalLength += chunk.length;
+              return callback(null, chunk);
+            },
+          }),
+        )
         .on('error', reject)
-        .on('end', () => {
-          writeStream.end();
+        .on('finish', () => {
           resolve([totalLength, md5Context.digest('hex')]);
-        });
+        })
+        .pipe(writeStream);
     });
     await fs.writeFile(`${partPath}.md5`, md5);
     return { size, md5 };


### PR DESCRIPTION
It allows use NodeJS backpressure: https://nodejs.org/es/docs/guides/backpressuring-in-streams/
In this way we will take out the return value of the .write() function.