### PR TITLE
Consistently return `this` from close

### DIFF
--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -198,6 +198,7 @@ class S3rver extends Koa {
     }
     if (typeof callback === 'function') {
       this.httpServer.close(callback);
+      return this;
     } else {
       return promisify(this.httpServer.close.bind(this.httpServer))();
     }


### PR DESCRIPTION
The JSDoc on `close` claims that it returns` this` when called with a callback, but in practice, it was only returning `this` if the server wasn't running.