### PR TITLE
Properly handle redirects for urls with anchors

### DIFF
--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -72,13 +72,21 @@ exports = module.exports = () =>
       if (err.code !== 'NoSuchKey') throw err;
 
       const key = err.detail.Key;
+      // SPA websites may have url anchors (ie: http://localhost/#my-anchor)
+      const [keyWithoutHash, keyHash] = key.split('#');
 
-      if (config.routingRules) {
+      if (keyWithoutHash === '' || keyWithoutHash.endsWith('/')) {
+        ctx.params = {
+          ...ctx.params,
+          key: keyWithoutHash + config.indexDocumentSuffix + (keyHash || ''),
+        };
+        await getObject(ctx);
+      } else if (config.routingRules) {
         for (const routingRule of config.routingRules) {
           // Only 404s are supported for RoutingRules right now, this may be a deviation from S3 behaviour but we don't
           // have a reproduction of a scenario where S3 does a redirect on a status code other than 404. If you're
           // reading this comment and you have a use-case, please raise an issue with details of your scenario. Thanks!
-          if (routingRule.shouldRedirect(key, 404)) {
+          if (routingRule.shouldRedirect(keyWithoutHash, 404)) {
             const location = routingRule.getRedirectLocation(key, {
               protocol: ctx.protocol,
               hostname: ctx.state.vhost
@@ -91,14 +99,6 @@ exports = module.exports = () =>
             return;
           }
         }
-      }
-
-      if (key === '' || key.endsWith('/')) {
-        ctx.params = {
-          ...ctx.params,
-          key: key + config.indexDocumentSuffix,
-        };
-        await getObject(ctx);
       } else {
         // Redirect keys that do not have a trailing slash when an index document exists
         const indexExists = await ctx.store.existsObject(


### PR DESCRIPTION
I recently ran into an issue where I was using s3rver to host an SPA that has routing.  I found this [ingenious hack](https://viastudio.com/hosting-a-reactjs-app-with-routing-on-aws-s3/) to make everything work on S3 but alas it did not work with serverless-offline and the s3rver.  This PR modifies the website routing logic to properly handle anchor tags.