### PR TITLE
Add test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/package.json
+++ b/package.json
@@ -25,10 +25,16 @@
   },
   "homepage": "https://github.com/jamhall/s3rver",
   "scripts": {
-    "test": "mocha --timeout 10000 --reporter spec --ui bdd",
+    "coverage": "nyc npm run test",
     "eslint": "eslint --ignore-path .gitignore \"**/*.js\"",
     "prettier-check": "prettier-check --ignore-path .gitignore \"**/*.{js,md}\"",
-    "format": "eslint --fix --ignore-path .gitignore \"**/*.js\" && prettier --ignore-path .gitignore --write \"**/*.{js,md}\""
+    "format": "eslint --fix --ignore-path .gitignore \"**/*.js\" && prettier --ignore-path .gitignore --write \"**/*.{js,md}\"",
+    "test": "mocha --timeout 10000 --reporter spec --ui bdd"
+  },
+  "nyc": {
+    "functions": 90,
+    "lines": 88,
+    "statements": 88
   },
   "main": "lib/s3rver.js",
   "files": [
@@ -77,6 +83,7 @@
     "md5": "2.2.1",
     "mocha": "7.1.0",
     "moment": "2.24.0",
+    "nyc": "^15.0.0",
     "prettier": "1.19.1",
     "prettier-check": "2.0.0",
     "promise-limit": "2.7.0",


### PR DESCRIPTION
As an aid to ensuring proper coverage, I've installed istanbul and configured coverage numbers that ought to ensure the threshold reflects current coverage and do not slip below those given numbers.
```
------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------
File                          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                          
------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------
All files                     |   88.38 |    76.48 |   90.87 |   88.78 |                                                                            
 lib                          |   84.76 |     51.3 |   93.33 |   84.23 |                                                                            
  routes.js                   |   78.05 |    34.83 |     100 |   77.78 | 24,38,74,79,107,112,122,151,156,168,170,184,189,200,202,213,222,227        
  s3rver.js                   |   82.64 |    65.96 |   88.24 |   82.35 | 70-72,99,111,116,122,152,153,175,191-194,196,233,237,247,253,259,260       
  utils.js                    |   96.97 |    94.44 |   93.75 |   96.67 | 65,85                                                                      
 lib/controllers              |   90.27 |    86.51 |     100 |   90.38 |                                                                            
  bucket.js                   |   90.43 |    87.84 |     100 |   91.15 | 146,157,171,184,199,206,285,290,376,380                                    
  object.js                   |   89.83 |    84.62 |     100 |   89.53 | 24,119,125,169,170,174,175,274,308,313,347,353,467,473,518,524,579,586     
  service.js                  |     100 |      100 |     100 |     100 |                                                                            
 lib/middleware               |   89.46 |    84.44 |   94.29 |   89.57 |                                                                            
  authentication.js           |    87.5 |    80.21 |     100 |   87.41 | 145,146,152,178,219,239,252,262,296,312,356,379,412,420,421,427,446        
  cors.js                     |   94.44 |    90.63 |     100 |   94.29 | 22,29                                                                      
  logger.js                   |     100 |      100 |     100 |     100 |                                                                            
  response-header-override.js |   95.65 |    92.31 |     100 |   95.45 | 35                                                                         
  vhost.js                    |     100 |      100 |     100 |     100 |                                                                            
  website.js                  |   86.24 |    82.35 |      75 |   86.79 | 16,24,49,50,174,178,188,194,200,201,239,242,247,249                        
 lib/models                   |   85.35 |    83.33 |   77.78 |   85.94 |                                                                            
  account.js                  |   81.82 |      100 |   66.67 |   81.82 | 16,17                                                                      
  bucket.js                   |     100 |      100 |     100 |     100 |                                                                            
  config.js                   |    78.3 |     81.2 |   73.91 |   79.21 | 28,38,49,65,74,142-144,146,157,167,180,181,187,188,204,216,224,238,245,351 
  error.js                    |   86.96 |    57.14 |      70 |   86.36 | 9,69,75                                                                    
  event.js                    |     100 |      100 |     100 |     100 |                                                                            
  object.js                   |     100 |      100 |     100 |     100 |                                                                            
  routing-rule.js             |   95.24 |    96.15 |     100 |   95.24 | 51                                                                         
 lib/stores                   |   91.36 |    73.49 |   90.57 |   93.69 |                                                                            
  filesystem.js               |   91.36 |    73.49 |   90.57 |   93.69 | 21,30,62,63,129,164,218,219,240,275,368,467,489                            
------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------
```

I would like to submit further pull requests with even more test coverage, and this would be a helpful tool.