### PR TITLE
Fix error when complete multipart upload

### DIFF
--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -485,7 +485,7 @@ exports.completeMultipartUpload = async function completeMultipartUpload(ctx) {
     .concat(ctx.request.body.CompleteMultipartUpload.Part)
     .map(part => ({
       number: Number(part.PartNumber),
-      etag: JSON.parse(part.ETag),
+      etag: JSON.stringify(part.ETag),
     }));
   try {
     const { md5, size } = await ctx.store.putObjectMultipart(


### PR DESCRIPTION
Before fix - JSON parse error. Because part.Etag is string.

After fix - upload success.