### PR TITLE
Fix v2 signature verification

### DIFF
--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -7,7 +7,11 @@ const querystring = require('querystring');
 const AWSAccount = require('../models/account');
 const S3Error = require('../models/error');
 const { RESPONSE_HEADERS } = require('./response-header-override');
-const { parseDate, parseISO8601String } = require('../utils');
+const {
+  encodeURIComponentRFC3986,
+  parseDate,
+  parseISO8601String,
+} = require('../utils');
 
 const SUBRESOURCES = {
   acl: 1,
@@ -99,6 +103,10 @@ module.exports = () =>
     } else {
       canonicalizedResource += '/';
     }
+    canonicalizedResource = canonicalizedResource
+      .split('/')
+      .map(encodeURIComponentRFC3986)
+      .join('/');
 
     const canonicalizedQueryString = Object.entries(query)
       .filter(

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -85,17 +85,21 @@ module.exports = () =>
       );
     }
 
-    const canonicalizedAmzHeaders = Object.keys(ctx.headers)
-      .filter(
-        headerName =>
-          headerName.startsWith('x-amz-') &&
-          headerName !== 'x-amz-website-redirect-location',
-      )
-      .sort()
-      .map(
-        headerName =>
-          `${headerName}:${ctx.get(headerName).replace(/ +/g, ' ')}`,
-      );
+    let canonicalizedResource = ctx.mountPath || '';
+    if (ctx.params.bucket) {
+      // the following behavior is derived from the behavior of the JS aws-sdk
+      if (ctx.state.vhost) {
+        canonicalizedResource = '/' + ctx.params.bucket + canonicalizedResource;
+      } else {
+        canonicalizedResource += '/' + ctx.params.bucket;
+      }
+      if (ctx.params.key) {
+        canonicalizedResource += '/' + ctx.params.key;
+      }
+    } else {
+      canonicalizedResource += '/';
+    }
+
     const canonicalizedQueryString = Object.entries(query)
       .filter(
         ([param]) =>
@@ -113,6 +117,18 @@ module.exports = () =>
       .join('&')
       .replace(/=(&|$)/g, ''); // remove trailing = for empty params
 
+    const canonicalizedAmzHeaders = Object.keys(ctx.headers)
+      .filter(
+        headerName =>
+          headerName.startsWith('x-amz-') &&
+          headerName !== 'x-amz-website-redirect-location',
+      )
+      .sort()
+      .map(
+        headerName =>
+          `${headerName}:${ctx.get(headerName).replace(/ +/g, ' ')}`,
+      );
+
     const canonicalRequest = {
       method:
         ctx.method === 'OPTIONS'
@@ -121,10 +137,7 @@ module.exports = () =>
       contentMD5: ctx.get('Content-MD5'),
       contentType: ctx.get('Content-Type'),
       timestamp: undefined,
-      // the following behavior is derived from the behavior of the JS aws-sdk
-      uri: ctx.state.vhost
-        ? `/${ctx.params.bucket}${ctx.mountPath || ''}/${ctx.params.key}`
-        : `${ctx.mountPath || ''}/${ctx.params.bucket}/${ctx.params.key}`,
+      uri: canonicalizedResource,
       querystring: canonicalizedQueryString,
       amzHeaders: canonicalizedAmzHeaders,
     };

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -57,10 +57,7 @@ module.exports = () =>
 
     const amzQueryHeaders = pickBy(
       mapKeys(ctx.query, (value, key) => key.toLowerCase()),
-      (value, key) =>
-        key.startsWith('x-amz-') &&
-        // x-amz-website-redirect-location isn't a canonical header
-        key !== 'x-amz-website-redirect-location',
+      (value, key) => key.startsWith('x-amz-'),
     );
     // x-amz-* values specified in query params take precedence over those in the headers
     Object.assign(ctx.headers, amzQueryHeaders);
@@ -125,11 +122,7 @@ module.exports = () =>
       .replace(/=(&|$)/g, ''); // remove trailing = for empty params
 
     const canonicalizedAmzHeaders = Object.keys(ctx.headers)
-      .filter(
-        headerName =>
-          headerName.startsWith('x-amz-') &&
-          headerName !== 'x-amz-website-redirect-location',
-      )
+      .filter(headerName => headerName.startsWith('x-amz-'))
       .sort()
       .map(
         headerName =>

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -55,9 +55,8 @@ module.exports = () =>
       return next();
     }
 
-    const query = mapKeys(ctx.query, (value, key) => key.toLowerCase());
     const amzQueryHeaders = pickBy(
-      query,
+      mapKeys(ctx.query, (value, key) => key.toLowerCase()),
       (value, key) =>
         key.startsWith('x-amz-') &&
         // x-amz-website-redirect-location isn't a canonical header
@@ -108,7 +107,7 @@ module.exports = () =>
       .map(encodeURIComponentRFC3986)
       .join('/');
 
-    const canonicalizedQueryString = Object.entries(query)
+    const canonicalizedQueryString = Object.entries(ctx.query)
       .filter(
         ([param]) =>
           SUBRESOURCES[param] ||

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -96,21 +96,22 @@ module.exports = () =>
         headerName =>
           `${headerName}:${ctx.get(headerName).replace(/ +/g, ' ')}`,
       );
-    const canonicalizedQueryString = Object.keys(query)
+    const canonicalizedQueryString = Object.entries(query)
       .filter(
-        paramName =>
-          SUBRESOURCES[paramName] ||
-          RESPONSE_HEADERS[paramName] ||
-          (mechanisms.queryV4 && paramName.startsWith('x-amz-')),
+        ([param]) =>
+          SUBRESOURCES[param] ||
+          RESPONSE_HEADERS[param] ||
+          (mechanisms.queryV4 && param.startsWith('x-amz-')),
       )
-      .map(paramName =>
+      .map(([param, value]) =>
         // v2 signing doesn't encode values in the signature calculation
         mechanisms.queryV2
-          ? [paramName, query[paramName]].join('=')
-          : querystring.stringify({ [paramName]: query[paramName] }),
+          ? [param, value].join('=')
+          : querystring.stringify({ [param]: value }),
       )
       .sort()
-      .join('&');
+      .join('&')
+      .replace(/=(&|$)/g, ''); // remove trailing = for empty params
 
     const canonicalRequest = {
       method:

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -134,7 +134,6 @@ module.exports = () =>
     if (mechanisms.header) {
       const result = parseHeader(ctx.headers);
       ({ signature, signatureProvided } = result);
-      canonicalRequest.timestamp = result.timestamp;
     } else if (mechanisms.queryV2) {
       const result = parseQueryV2(ctx.query, ctx.headers);
       ({ signature, signatureProvided } = result);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -231,7 +231,7 @@ router
 
 // append trailing slash to key when applicable
 router.param('key', (key, ctx, next) => {
-  if (ctx.path.endsWith('/')) {
+  if (key && ctx.path.endsWith('/')) {
     ctx.params.key = key + '/';
   }
   return next();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,6 +55,24 @@ exports.concatStreams = function(streams) {
   return passThrough;
 };
 
+/**
+ * URI-encodes a string according to RFC 3986. This is what AWS uses for
+ * S3 resource URIs.
+ *
+ * @param {string} string
+ */
+exports.encodeURIComponentRFC3986 = function(string) {
+  return encodeURIComponent(string).replace(
+    /[!'()*]/g,
+    ch =>
+      '%' +
+      ch
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase(),
+  );
+};
+
 exports.getXmlRootTag = function(xml) {
   const traversal = xmlParser.getTraversalObj(xml.toString());
   const [[root]] = Object.values(traversal.child);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -50,6 +50,7 @@ exports.createServerAndClient = async function createServerAndClient(options) {
     endpoint: `http://localhost:${port}`,
     sslEnabled: false,
     s3ForcePathStyle: true,
+    signatureVersion: 'v2',
   });
 
   return { s3rver, s3Client };


### PR DESCRIPTION
Originally I was under the impression that our test suite ran using v2 signatures for all requests, but they're actually defaulting to v4 signatures (and S3rver makes no attempt to verify those). Turning on v2 signatures makes a whopping 101/184 tests fail!

This PR fixes all v2 verification errors within the testing suite and resolves #513 (closes #526).