### PR TITLE
Use looser ETag parsing in Complete Multipart Upload requests

### DIFF
--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -623,11 +623,22 @@ exports.putObjectTagging = async function putObject(ctx) {
  */
 exports.completeMultipartUpload = async function completeMultipartUpload(ctx) {
   await xmlBodyParser(ctx);
+  if (
+    !ctx.request.body.CompleteMultipartUpload ||
+    !ctx.request.body.CompleteMultipartUpload.Part
+  ) {
+    throw new S3Error(
+      'MalformedXML',
+      'The XML you provided was not well-formed or did not validate against ' +
+        'our published schema.',
+    );
+  }
   const parts = []
     .concat(ctx.request.body.CompleteMultipartUpload.Part)
     .map(part => ({
       number: Number(part.PartNumber),
-      etag: JSON.parse(part.ETag),
+      // S3 removes all double quotes when comparing etags
+      etag: part.ETag.replace(/"/g, ''),
     }));
   try {
     const { md5, size } = await ctx.store.putObjectMultipart(

--- a/test/controllers/object.spec.js
+++ b/test/controllers/object.spec.js
@@ -1151,6 +1151,35 @@ describe('Operations on Objects', () => {
       expect(data.ETag).to.match(/"[a-fA-F0-9]{32}"/);
     });
 
+    it('completes a multipart upload with unquoted ETags', async function() {
+      const data = await s3Client
+        .createMultipartUpload({
+          Bucket: 'bucket-a',
+          Key: 'multi/directory/path/multipart',
+        })
+        .promise();
+      const partRes = await s3Client
+        .uploadPart({
+          Body: 'Hello!',
+          PartNumber: 1,
+          ...data,
+        })
+        .promise();
+      await s3Client
+        .completeMultipartUpload({
+          MultipartUpload: {
+            Parts: [
+              {
+                PartNumber: 1,
+                ETag: JSON.parse(partRes.ETag),
+              },
+            ],
+          },
+          ...data,
+        })
+        .promise();
+    });
+
     it('completes a multipart upload with metadata', async function() {
       const data = await s3Client
         .upload({


### PR DESCRIPTION
Closes #629. This fixes requests where the ETag for each part is sent without surrounding double quotes.