### PR TITLE
Support disabling vhost-style bucket access

### DIFF
--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -62,13 +62,14 @@ program
   )
   .option(
     '--service-endpoint <address>',
-    'Overrides the AWS S3 service endpoint',
+    'Overrides the AWS service root for subdomain-style access',
     S3rver.defaultOptions.serviceEndpoint,
   )
   .option(
     '--allow-mismatched-signatures',
     'Prevent SignatureDoesNotMatch errors for all well-formed signatures',
   )
+  .option('--no-vhost-buckets', 'Disables vhost-style access for all buckets')
   // NOTE: commander doesn't actually support options with multiple parts,
   // we must manually parse this option
   .option(

--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -7,10 +7,10 @@ const { hostname } = require('os');
 /**
  * Middleware that rewrites URLs for buckets specified via subdomain or host header
  */
-module.exports = () =>
+module.exports = ({ serviceEndpoint, vhostBuckets }) =>
   function vhost(ctx, next) {
     // prettier-ignore
-    const pattern = RegExp(`^(?:(.+)\\.)?s3(-website)?([-.].+)?\\.${escapeRegExp(ctx.app.serviceEndpoint)}$`);
+    const pattern = RegExp(`^(?:(.+)\\.)?s3(-website)?([-.].+)?\\.${escapeRegExp(serviceEndpoint)}$`);
     const [match, bucket, website] = pattern.exec(ctx.hostname) || [];
     ctx.state.vhost = Boolean(bucket);
     if (match) {
@@ -32,6 +32,7 @@ module.exports = () =>
         }
       }
       if (
+        vhostBuckets &&
         !isIP(ctx.hostname) &&
         !['localhost', hostname()].includes(ctx.hostname)
       ) {

--- a/lib/middleware/vhost.js
+++ b/lib/middleware/vhost.js
@@ -2,6 +2,7 @@
 
 const { escapeRegExp } = require('lodash');
 const { isIP } = require('net');
+const { hostname } = require('os');
 
 /**
  * Middleware that rewrites URLs for buckets specified via subdomain or host header
@@ -30,7 +31,10 @@ module.exports = () =>
           break;
         }
       }
-      if (!isIP(ctx.hostname) && ctx.hostname !== 'localhost') {
+      if (
+        !isIP(ctx.hostname) &&
+        !['localhost', hostname()].includes(ctx.hostname)
+      ) {
         ctx.state.vhost = true;
         // otherwise attempt to distinguish virtual host-style requests
         ctx.path = `/${ctx.hostname}${ctx.path}`;

--- a/lib/s3rver.js
+++ b/lib/s3rver.js
@@ -28,13 +28,13 @@ class S3rver extends Koa {
       directory,
       resetOnClose,
       allowMismatchedSignatures,
+      vhostBuckets,
       configureBuckets,
       ...serverOptions
     } = defaults({}, options, S3rver.defaultOptions);
     this.serverOptions = serverOptions;
     this._configureBuckets = configureBuckets;
     this.silent = silent;
-    this.serviceEndpoint = serviceEndpoint;
     this.resetOnClose = resetOnClose;
     this.allowMismatchedSignatures = allowMismatchedSignatures;
     this.store = this.context.store = new FilesystemStore(directory);
@@ -64,7 +64,7 @@ class S3rver extends Koa {
         return next();
       });
 
-      this.use(vhostMiddleware());
+      this.use(vhostMiddleware({ serviceEndpoint, vhostBuckets }));
       this.use(router.routes());
     } catch (err) {
       this.logger.exceptions.unhandle();
@@ -214,6 +214,7 @@ S3rver.defaultOptions = {
   directory: path.join(os.tmpdir(), 's3rver'),
   resetOnClose: false,
   allowMismatchedSignatures: false,
+  vhostBuckets: true,
   configureBuckets: [],
 };
 S3rver.prototype.getMiddleware = S3rver.prototype.callback;

--- a/test/middleware/vhost.spec.js
+++ b/test/middleware/vhost.spec.js
@@ -13,27 +13,47 @@ const request = require('request-promise-native').defaults({
 const { createServerAndClient } = require('../helpers');
 
 describe('Virtual Host resolution', () => {
-  let s3Client;
-  const buckets = [{ name: 'bucket0' }, { name: 'bucket1' }];
+  const buckets = [{ name: 'bucket-a' }, { name: 'bucket-b' }];
 
-  beforeEach(async function() {
-    ({ s3Client } = await createServerAndClient({
+  it('lists objects with subdomain-domain style bucket access', async function() {
+    const { s3Client } = await createServerAndClient({
       configureBuckets: buckets,
-    }));
+    });
+    const res = await request(s3Client.config.endpoint, {
+      headers: { host: 'bucket-a.s3.amazonaws.com' },
+    });
+    expect(res.body).to.include(`<Name>bucket-a</Name>`);
   });
 
-  it('reaches the server with a bucket subdomain', async function() {
-    const res = await request(s3Client.config.endpoint, {
-      headers: { host: 'bucket0.s3.amazonaws.com' },
+  it('lists objects with a vhost-style bucket access', async function() {
+    const { s3Client } = await createServerAndClient({
+      configureBuckets: buckets,
     });
-    expect(res.body).to.include(`<Name>bucket0</Name>`);
+    const res = await request(s3Client.config.endpoint, {
+      headers: { host: 'bucket-a' },
+    });
+    expect(res.body).to.include(`<Name>bucket-a</Name>`);
   });
 
-  it('reaches the server with a bucket vhost', async function() {
-    const res = await request(s3Client.config.endpoint, {
-      headers: { host: 'bucket0' },
+  it('lists buckets when vhost-style bucket access is disabled', async function() {
+    const { s3Client } = await createServerAndClient({
+      vhostBuckets: false,
+      configureBuckets: buckets,
     });
-    expect(res.body).to.include(`<Name>bucket0</Name>`);
+    const res = await request(s3Client.config.endpoint, {
+      headers: { host: 'bucket-a' },
+    });
+    const parsedBody = xmlParser.parse(res.body, {
+      tagValueProcessor: a => he.decode(a),
+    });
+    expect(parsedBody).to.haveOwnProperty('ListAllMyBucketsResult');
+    const parsedBuckets = parsedBody.ListAllMyBucketsResult.Buckets.Bucket;
+    expect(parsedBuckets).to.be.instanceOf(Array);
+    expect(parsedBuckets).to.have.lengthOf(buckets.length);
+    for (const [bucket, config] of zip(parsedBuckets, buckets)) {
+      expect(bucket.Name).to.equal(config.name);
+      expect(moment(bucket.CreationDate).isValid()).to.be.true;
+    }
   });
 
   it('lists buckets at a custom service endpoint', async function() {
@@ -83,11 +103,11 @@ describe('Virtual Host resolution', () => {
       configureBuckets: buckets,
     });
     const res = await request(s3Client.config.endpoint, {
-      headers: { host: 'bucket0.s3.example.com' },
+      headers: { host: 'bucket-a.s3.example.com' },
     });
     const parsedBody = xmlParser.parse(res.body, {
       tagValueProcessor: a => he.decode(a),
     });
-    expect(parsedBody.ListBucketResult.Name).to.equal('bucket0');
+    expect(parsedBody.ListBucketResult.Name).to.equal('bucket-a');
   });
 });

--- a/test/middleware/vhost.spec.js
+++ b/test/middleware/vhost.spec.js
@@ -5,6 +5,7 @@ const xmlParser = require('fast-xml-parser');
 const { zip } = require('lodash');
 const he = require('he');
 const moment = require('moment');
+const os = require('os');
 const request = require('request-promise-native').defaults({
   resolveWithFullResponse: true,
 });
@@ -42,6 +43,26 @@ describe('Virtual Host resolution', () => {
     });
     const res = await request(s3Client.config.endpoint, {
       headers: { host: 's3.example.com' },
+    });
+    const parsedBody = xmlParser.parse(res.body, {
+      tagValueProcessor: a => he.decode(a),
+    });
+    expect(parsedBody).to.haveOwnProperty('ListAllMyBucketsResult');
+    const parsedBuckets = parsedBody.ListAllMyBucketsResult.Buckets.Bucket;
+    expect(parsedBuckets).to.be.instanceOf(Array);
+    expect(parsedBuckets).to.have.lengthOf(buckets.length);
+    for (const [bucket, config] of zip(parsedBuckets, buckets)) {
+      expect(bucket.Name).to.equal(config.name);
+      expect(moment(bucket.CreationDate).isValid()).to.be.true;
+    }
+  });
+
+  it('lists buckets at the OS hostname', async function() {
+    const { s3Client } = await createServerAndClient({
+      configureBuckets: buckets,
+    });
+    const res = await request(s3Client.config.endpoint, {
+      headers: { host: os.hostname() },
     });
     const parsedBody = xmlParser.parse(res.body, {
       tagValueProcessor: a => he.decode(a),


### PR DESCRIPTION
Resolves #557 (closes #558). This adds `vhostBuckets` to the constructor options and a `--no-vhost-buckets` option to the CLI. This also prevents the OS or container's own hostname from being interpreted as a bucket name regardless of the setting. Virtual host style access is still enabled by default with these changes.