### PR TITLE
Drop fs-extra as dependency

### DIFF
--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -9,7 +9,7 @@ const pkg = require('../package.json');
 const S3rver = require('..');
 
 function ensureDirectory(directory) {
-  fs.mkdir(directory, {recursive: true});
+  fs.mkdir(directory, { recursive: true });
   return directory;
 }
 

--- a/bin/s3rver.js
+++ b/bin/s3rver.js
@@ -3,13 +3,13 @@
 
 /* eslint-disable no-console */
 
-const fs = require('fs-extra');
+const fs = require('fs');
 const program = require('commander');
 const pkg = require('../package.json');
 const S3rver = require('..');
 
 function ensureDirectory(directory) {
-  fs.ensureDirSync(directory);
+  fs.mkdir(directory, {recursive: true});
   return directory;
 }
 

--- a/lib/models/object.js
+++ b/lib/models/object.js
@@ -10,7 +10,7 @@ class S3Object {
     this.metadata = pick(metadata, [
       ...S3Object.ALLOWED_METADATA,
 
-      // instrinsic metadata determined when retrieving objects
+      // intrinsic metadata determined when retrieving objects
       'last-modified',
       'etag',
       'content-length',

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -2,7 +2,12 @@
 
 const crypto = require('crypto');
 const fs = require('fs').promises;
-const { createReadStream, createWriteStream, rmdirSync, readdirSync } = require('fs');
+const {
+  createReadStream,
+  createWriteStream,
+  rmdirSync,
+  readdirSync,
+} = require('fs');
 const { Transform } = require('stream');
 const { pick, pickBy, sortBy, zip } = require('lodash');
 const path = require('path');
@@ -106,8 +111,8 @@ class FilesystemStore {
 
   reset() {
     const list = readdirSync(this.rootDirectory);
-    for (const file of list){
-      rmdirSync(path.join(this.rootDirectory, file), {recursive: true});
+    for (const file of list) {
+      rmdirSync(path.join(this.rootDirectory, file), { recursive: true });
     }
   }
 
@@ -133,12 +138,12 @@ class FilesystemStore {
 
   async putBucket(bucket) {
     const bucketPath = this.getBucketPath(bucket);
-    await fs.mkdir(bucketPath, 0o0755, {recursive: true});
+    await fs.mkdir(bucketPath, 0o0755, { recursive: true });
     return this.getBucket(bucket);
   }
 
   async deleteBucket(bucket) {
-    return fs.rmdir(this.getBucketPath(bucket), {recursive: true});
+    return fs.rmdir(this.getBucketPath(bucket), { recursive: true });
   }
 
   async listObjects(bucket, options) {
@@ -261,7 +266,10 @@ class FilesystemStore {
       }
 
       const content = await new Promise((resolve, reject) => {
-        const stream = createReadStream(this.getResourcePath(bucket, key, 'object'), range)
+        const stream = createReadStream(
+          this.getResourcePath(bucket, key, 'object'),
+          range,
+        )
           .on('error', reject)
           .on('open', () => resolve(stream));
       });
@@ -283,7 +291,7 @@ class FilesystemStore {
       'object',
     );
 
-    await fs.mkdir(path.dirname(objectPath), {recursive: true});
+    await fs.mkdir(path.dirname(objectPath), { recursive: true });
 
     const [size, md5] = await new Promise((resolve, reject) => {
       const writeStream = createWriteStream(objectPath);
@@ -325,7 +333,7 @@ class FilesystemStore {
     const destObjectPath = this.getResourcePath(destBucket, destKey, 'object');
 
     if (srcObjectPath !== destObjectPath) {
-      await fs.mkdir(path.dirname(destObjectPath), {recursive: true});
+      await fs.mkdir(path.dirname(destObjectPath), { recursive: true });
       await fs.copyFile(srcObjectPath, destObjectPath);
     }
 
@@ -381,7 +389,7 @@ class FilesystemStore {
       uploadId,
     );
 
-    await fs.mkdir(uploadDir, {recursive: true});
+    await fs.mkdir(uploadDir, { recursive: true });
 
     await Promise.all([
       fs.writeFile(path.join(uploadDir, 'key'), key),
@@ -396,7 +404,7 @@ class FilesystemStore {
       partNumber.toString(),
     );
 
-    await fs.mkdir(path.dirname(partPath), {recursive: true});
+    await fs.mkdir(path.dirname(partPath), { recursive: true });
 
     const [size, md5] = await new Promise((resolve, reject) => {
       const writeStream = createWriteStream(partPath);
@@ -442,7 +450,7 @@ class FilesystemStore {
       metadata,
     );
     const result = await this.putObject(object);
-    await fs.rmdir(uploadDir, {recursive: true});
+    await fs.rmdir(uploadDir, { recursive: true });
     return result;
   }
 

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const crypto = require('crypto');
-const fs = require('fs-extra');
+const fs = require('fs').promises;
+const { createReadStream, createWriteStream, rmdirSync, readdirSync } = require('fs');
 const { Transform } = require('stream');
 const { pick, pickBy, sortBy, zip } = require('lodash');
 const path = require('path');
@@ -69,7 +70,7 @@ class FilesystemStore {
           if (err.code !== 'ENOENT') throw err;
           // create the md5 file if it doesn't already exist
           const md5 = await new Promise((resolve, reject) => {
-            const stream = fs.createReadStream(objectPath);
+            const stream = createReadStream(objectPath);
             const md5Context = crypto.createHash('md5');
             stream.on('error', reject);
             stream.on('data', chunk => md5Context.update(chunk, 'utf8'));
@@ -104,9 +105,9 @@ class FilesystemStore {
   // store implementation
 
   reset() {
-    const list = fs.readdirSync(this.rootDirectory);
-    for (const file of list) {
-      fs.removeSync(path.join(this.rootDirectory, file));
+    const list = readdirSync(this.rootDirectory);
+    for (const file of list){
+      rmdirSync(path.join(this.rootDirectory, file), {recursive: true});
     }
   }
 
@@ -132,12 +133,12 @@ class FilesystemStore {
 
   async putBucket(bucket) {
     const bucketPath = this.getBucketPath(bucket);
-    await fs.mkdirp(bucketPath, 0o0755);
+    await fs.mkdir(bucketPath, 0o0755, {recursive: true});
     return this.getBucket(bucket);
   }
 
   async deleteBucket(bucket) {
-    return fs.remove(this.getBucketPath(bucket));
+    return fs.rmdir(this.getBucketPath(bucket), {recursive: true});
   }
 
   async listObjects(bucket, options) {
@@ -260,8 +261,7 @@ class FilesystemStore {
       }
 
       const content = await new Promise((resolve, reject) => {
-        const stream = fs
-          .createReadStream(this.getResourcePath(bucket, key, 'object'), range)
+        const stream = createReadStream(this.getResourcePath(bucket, key, 'object'), range)
           .on('error', reject)
           .on('open', () => resolve(stream));
       });
@@ -283,10 +283,10 @@ class FilesystemStore {
       'object',
     );
 
-    await fs.mkdirp(path.dirname(objectPath));
+    await fs.mkdir(path.dirname(objectPath), {recursive: true});
 
     const [size, md5] = await new Promise((resolve, reject) => {
-      const writeStream = fs.createWriteStream(objectPath);
+      const writeStream = createWriteStream(objectPath);
       const md5Context = crypto.createHash('md5');
 
       if (Buffer.isBuffer(object.content)) {
@@ -325,8 +325,8 @@ class FilesystemStore {
     const destObjectPath = this.getResourcePath(destBucket, destKey, 'object');
 
     if (srcObjectPath !== destObjectPath) {
-      await fs.mkdirp(path.dirname(destObjectPath));
-      await fs.copy(srcObjectPath, destObjectPath);
+      await fs.mkdir(path.dirname(destObjectPath), {recursive: true});
+      await fs.copyFile(srcObjectPath, destObjectPath);
     }
 
     if (replacementMetadata) {
@@ -335,11 +335,11 @@ class FilesystemStore {
     } else {
       if (srcObjectPath !== destObjectPath) {
         await Promise.all([
-          fs.copy(
+          fs.copyFile(
             this.getResourcePath(srcBucket, srcKey, 'metadata.json'),
             this.getResourcePath(destBucket, destKey, 'metadata.json'),
           ),
-          fs.copy(
+          fs.copyFile(
             this.getResourcePath(srcBucket, srcKey, 'object.md5'),
             this.getResourcePath(destBucket, destKey, 'object.md5'),
           ),
@@ -368,7 +368,7 @@ class FilesystemStore {
     parts.pop();
     while (
       parts.length &&
-      !fs.readdirSync(path.join(bucketPath, ...parts)).length
+      !readdirSync(path.join(bucketPath, ...parts)).length
     ) {
       await fs.rmdir(path.join(bucketPath, ...parts));
       parts.pop();
@@ -381,7 +381,7 @@ class FilesystemStore {
       uploadId,
     );
 
-    await fs.mkdirp(uploadDir);
+    await fs.mkdir(uploadDir, {recursive: true});
 
     await Promise.all([
       fs.writeFile(path.join(uploadDir, 'key'), key),
@@ -396,10 +396,10 @@ class FilesystemStore {
       partNumber.toString(),
     );
 
-    await fs.mkdirp(path.dirname(partPath));
+    await fs.mkdir(path.dirname(partPath), {recursive: true});
 
     const [size, md5] = await new Promise((resolve, reject) => {
-      const writeStream = fs.createWriteStream(partPath);
+      const writeStream = createWriteStream(partPath);
       const md5Context = crypto.createHash('md5');
       let totalLength = 0;
 
@@ -433,7 +433,7 @@ class FilesystemStore {
       fs.readFile(path.join(uploadDir, 'metadata')).then(JSON.parse),
     ]);
     const partStreams = sortBy(parts, part => part.number).map(part =>
-      fs.createReadStream(path.join(uploadDir, part.number.toString())),
+      createReadStream(path.join(uploadDir, part.number.toString())),
     );
     const object = new S3Object(
       bucket,
@@ -442,7 +442,7 @@ class FilesystemStore {
       metadata,
     );
     const result = await this.putObject(object);
-    await fs.remove(uploadDir);
+    await fs.rmdir(uploadDir, {recursive: true});
     return result;
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 const crypto = require('crypto');
 const xmlParser = require('fast-xml-parser');
-const fs = require('fs-extra');
+const fs = require('fs');
 const path = require('path');
 const { PassThrough } = require('stream');
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "busboy": "^0.3.1",
     "commander": "^5.0.0",
     "fast-xml-parser": "^3.12.19",
-    "fs-extra": "^8.0.0",
     "he": "^1.2.0",
     "koa": "^2.7.0",
     "koa-logger": "^3.2.0",

--- a/test/controllers/bucket.spec.js
+++ b/test/controllers/bucket.spec.js
@@ -17,9 +17,7 @@ describe('Operations on Buckets', () => {
     // AWS default CORS settings when enabling it in the UI
     {
       name: 'cors-test0',
-      configs: [
-        fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))
-      ],
+      configs: [fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))],
     },
 
     // A standard static hosting configuration with no custom error page

--- a/test/controllers/bucket.spec.js
+++ b/test/controllers/bucket.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
-const fs = require('fs-extra');
+const fs = require('fs');
 const { find } = require('lodash');
 
 const { createServerAndClient, generateTestObjects } = require('../helpers');
@@ -17,7 +17,9 @@ describe('Operations on Buckets', () => {
     // AWS default CORS settings when enabling it in the UI
     {
       name: 'cors-test0',
-      configs: [fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))],
+      configs: [
+        fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))
+      ],
     },
 
     // A standard static hosting configuration with no custom error page

--- a/test/controllers/object.spec.js
+++ b/test/controllers/object.spec.js
@@ -3,7 +3,7 @@
 const { expect } = require('chai');
 const express = require('express');
 const FormData = require('form-data');
-const fs = require('fs-extra');
+const fs = require('fs');
 const { find, times } = require('lodash');
 const md5 = require('md5');
 const moment = require('moment');
@@ -122,7 +122,7 @@ describe('Operations on Objects', () => {
 
     it('gets an image from a bucket', async function() {
       const file = require.resolve('../fixtures/image0.jpg');
-      const data = await fs.readFile(file);
+      const data = await fs.promises.readFile(file);
       await s3Client
         .putObject({
           Bucket: 'bucket-a',
@@ -159,7 +159,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: 'image',
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -178,12 +178,12 @@ describe('Operations on Objects', () => {
 
     it('returns 416 error for out of bounds range requests', async function() {
       const file = require.resolve('../fixtures/image0.jpg');
-      const filesize = fs.statSync(file).size;
+      const {size: filesize} = fs.statSync(file);
       await s3Client
         .putObject({
           Bucket: 'bucket-a',
           Key: 'image',
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -206,12 +206,12 @@ describe('Operations on Objects', () => {
 
     it('returns actual length of data for partial out of bounds range requests', async function() {
       const file = require.resolve('../fixtures/image0.jpg');
-      const filesize = fs.statSync(file).size;
+      const {size: filesize} = fs.statSync(file);
       await s3Client
         .putObject({
           Bucket: 'bucket-a',
           Key: 'image',
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -252,7 +252,7 @@ describe('Operations on Objects', () => {
 
     it('returns image metadata from a bucket in HEAD request', async function() {
       const file = require.resolve('../fixtures/image0.jpg');
-      const fileContent = await fs.readFile(file);
+      const fileContent = await fs.promises.readFile(file);
       await s3Client
         .putObject({
           Bucket: 'bucket-a',
@@ -690,7 +690,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: 'image',
-          Body: await fs.readFile(files[0]),
+          Body: await fs.promises.readFile(files[0]),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -703,7 +703,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: 'image',
-          Body: await fs.readFile(files[1]),
+          Body: await fs.promises.readFile(files[1]),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -794,7 +794,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: 'image',
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -807,7 +807,7 @@ describe('Operations on Objects', () => {
       const params = {
         Bucket: 'bucket-a',
         Key: 'jquery',
-        Body: await fs.readFile(file),
+        Body: await fs.promises.readFile(file),
         ContentType: 'application/javascript',
         ContentEncoding: 'gzip',
       };
@@ -867,7 +867,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: srcKey,
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -899,7 +899,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: srcKey,
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
           Metadata: {
             someKey: 'value',
@@ -932,7 +932,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: srcKey,
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -957,7 +957,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: srcKey,
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -988,7 +988,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: srcKey,
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -1019,7 +1019,7 @@ describe('Operations on Objects', () => {
         .putObject({
           Bucket: 'bucket-a',
           Key: key,
-          Body: await fs.readFile(file),
+          Body: await fs.promises.readFile(file),
           ContentType: 'image/jpeg',
         })
         .promise();

--- a/test/controllers/object.spec.js
+++ b/test/controllers/object.spec.js
@@ -178,7 +178,7 @@ describe('Operations on Objects', () => {
 
     it('returns 416 error for out of bounds range requests', async function() {
       const file = require.resolve('../fixtures/image0.jpg');
-      const {size: filesize} = fs.statSync(file);
+      const { size: filesize } = fs.statSync(file);
       await s3Client
         .putObject({
           Bucket: 'bucket-a',
@@ -206,7 +206,7 @@ describe('Operations on Objects', () => {
 
     it('returns actual length of data for partial out of bounds range requests', async function() {
       const file = require.resolve('../fixtures/image0.jpg');
-      const {size: filesize} = fs.statSync(file);
+      const { size: filesize } = fs.statSync(file);
       await s3Client
         .putObject({
           Bucket: 'bucket-a',

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -19,7 +19,7 @@ exports.resetTmpDir = function resetTmpDir() {
   } catch (err) {
     /* directory didn't exist */
   }
-  fs.mkdirSync(tmpDir);
+  fs.mkdirSync(tmpDir, {recursive: true});
 };
 
 exports.generateTestObjects = function generateTestObjects(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const fs = require('fs-extra');
+const fs = require('fs');
 const { times } = require('lodash');
 const os = require('os');
 const path = require('path');
@@ -15,11 +15,11 @@ const instances = new Set();
 
 exports.resetTmpDir = function resetTmpDir() {
   try {
-    fs.removeSync(tmpDir);
+    fs.rmdirSync(tmpDir, {recursive: true});
   } catch (err) {
     /* directory didn't exist */
   }
-  fs.ensureDirSync(tmpDir);
+  fs.mkdirSync(tmpDir);
 };
 
 exports.generateTestObjects = function generateTestObjects(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -15,11 +15,18 @@ const instances = new Set();
 
 exports.resetTmpDir = function resetTmpDir() {
   try {
-    fs.rmdirSync(tmpDir, {recursive: true});
+    fs.rmdirSync(tmpDir, { recursive: true });
   } catch (err) {
     /* directory didn't exist */
   }
-  fs.mkdirSync(tmpDir, {recursive: true});
+  try {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  } catch (err) {
+    /* parallel recreated */
+    if (err.code !== 'EEXIST') {
+      throw err;
+    }
+  }
 };
 
 exports.generateTestObjects = function generateTestObjects(

--- a/test/middleware/authentication.spec.js
+++ b/test/middleware/authentication.spec.js
@@ -279,7 +279,9 @@ describe('REST Authentication', () => {
       .putObject({
         Bucket: 'bucket-a',
         Key: 'image',
-        Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
+        Body: await fs.promises.readFile(
+          require.resolve('../fixtures/image0.jpg'),
+        ),
       })
       .promise();
     const url = s3Client.getSignedUrl('getObject', {
@@ -298,7 +300,9 @@ describe('REST Authentication', () => {
       .putObject({
         Bucket: 'bucket-a',
         Key: 'image',
-        Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
+        Body: await fs.promises.readFile(
+          require.resolve('../fixtures/image0.jpg'),
+        ),
       })
       .promise();
     let res;

--- a/test/middleware/authentication.spec.js
+++ b/test/middleware/authentication.spec.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai');
 const express = require('express');
-const fs = require('fs-extra');
+const fs = require('fs');
 const request = require('request-promise-native').defaults({
   resolveWithFullResponse: true,
 });
@@ -279,7 +279,7 @@ describe('REST Authentication', () => {
       .putObject({
         Bucket: 'bucket-a',
         Key: 'image',
-        Body: await fs.readFile(require.resolve('../fixtures/image0.jpg')),
+        Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
       })
       .promise();
     const url = s3Client.getSignedUrl('getObject', {
@@ -298,7 +298,7 @@ describe('REST Authentication', () => {
       .putObject({
         Bucket: 'bucket-a',
         Key: 'image',
-        Body: await fs.readFile(require.resolve('../fixtures/image0.jpg')),
+        Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
       })
       .promise();
     let res;

--- a/test/middleware/cors.spec.js
+++ b/test/middleware/cors.spec.js
@@ -2,7 +2,7 @@
 
 const AWS = require('aws-sdk');
 const { expect } = require('chai');
-const fs = require('fs-extra');
+const fs = require('fs');
 const request = require('request-promise-native').defaults({
   resolveWithFullResponse: true,
 });
@@ -14,7 +14,9 @@ describe('CORS Policy Tests', function() {
     // provides rules for origins http://a-test.example.com and http://*.bar.com
     {
       name: 'bucket0',
-      configs: [fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))],
+      configs: [
+        fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))
+      ],
     },
   ];
 
@@ -115,7 +117,9 @@ describe('CORS Policy Tests', function() {
     const origin = 'http://a-test.example.com';
     const bucket = {
       name: 'foobars',
-      configs: [fs.readFileSync('./example/cors.xml')],
+      configs: [
+        fs.readFileSync('./example/cors.xml')
+      ],
     };
 
     const server = new S3rver({
@@ -134,7 +138,7 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: bucket.name,
           Key: 'image',
-          Body: await fs.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -170,7 +174,7 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -209,7 +213,7 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -248,7 +252,7 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -284,7 +288,7 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
           ContentType: 'image/jpeg',
         })
         .promise();

--- a/test/middleware/cors.spec.js
+++ b/test/middleware/cors.spec.js
@@ -14,9 +14,7 @@ describe('CORS Policy Tests', function() {
     // provides rules for origins http://a-test.example.com and http://*.bar.com
     {
       name: 'bucket0',
-      configs: [
-        fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))
-      ],
+      configs: [fs.readFileSync(require.resolve('../fixtures/cors-test0.xml'))],
     },
   ];
 
@@ -117,9 +115,7 @@ describe('CORS Policy Tests', function() {
     const origin = 'http://a-test.example.com';
     const bucket = {
       name: 'foobars',
-      configs: [
-        fs.readFileSync('./example/cors.xml')
-      ],
+      configs: [fs.readFileSync('./example/cors.xml')],
     };
 
     const server = new S3rver({
@@ -138,7 +134,9 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: bucket.name,
           Key: 'image',
-          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(
+            require.resolve('../fixtures/image0.jpg'),
+          ),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -174,7 +172,9 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(
+            require.resolve('../fixtures/image0.jpg'),
+          ),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -213,7 +213,9 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(
+            require.resolve('../fixtures/image0.jpg'),
+          ),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -252,7 +254,9 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(
+            require.resolve('../fixtures/image0.jpg'),
+          ),
           ContentType: 'image/jpeg',
         })
         .promise();
@@ -288,7 +292,9 @@ describe('CORS Policy Tests', function() {
         .putObject({
           Bucket: buckets[0].name,
           Key: 'image',
-          Body: await fs.promises.readFile(require.resolve('../fixtures/image0.jpg')),
+          Body: await fs.promises.readFile(
+            require.resolve('../fixtures/image0.jpg'),
+          ),
           ContentType: 'image/jpeg',
         })
         .promise();

--- a/test/middleware/website.spec.js
+++ b/test/middleware/website.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
-const fs = require('fs-extra');
+const fs = require('fs');
 const request = require('request-promise-native').defaults({
   resolveWithFullResponse: true,
 });

--- a/test/s3rver.test.js
+++ b/test/s3rver.test.js
@@ -4,7 +4,7 @@ const AWS = require('aws-sdk');
 const { expect } = require('chai');
 const express = require('express');
 const FormData = require('form-data');
-const fs = require('fs-extra');
+const fs = require('fs');
 const md5 = require('md5');
 const request = require('request-promise-native').defaults({
   resolveWithFullResponse: true,


### PR DESCRIPTION
Current NodeJS versions have support for ```fs.promises```. In this case, fs-extra is not necessary. See also #638 for drop support for NodeJS 8.