### PR TITLE
Implement support for signature v4

### DIFF
--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const { createHmac } = require('crypto');
+const { createHmac, createHash } = require('crypto');
 const { mapKeys, pickBy } = require('lodash');
-const querystring = require('querystring');
 
 const AWSAccount = require('../models/account');
 const S3Error = require('../models/error');
@@ -52,6 +51,11 @@ module.exports = () =>
   async function authentication(ctx, next) {
     if (ctx.state.website) {
       // skip for static website requests
+      return next();
+    }
+
+    if (ctx.method === 'OPTIONS') {
+      // skip for CORS OPTION requests
       return next();
     }
 
@@ -109,17 +113,18 @@ module.exports = () =>
         ([param]) =>
           SUBRESOURCES[param] ||
           RESPONSE_HEADERS[param] ||
-          (mechanisms.queryV4 && param.startsWith('x-amz-')),
+          (mechanisms.queryV4 &&
+            param.startsWith('X-Amz-') &&
+            param !== 'X-Amz-Signature'),
       )
-      .map(([param, value]) =>
-        // v2 signing doesn't encode values in the signature calculation
-        mechanisms.queryV2
-          ? [param, value].join('=')
-          : querystring.stringify({ [param]: value }),
+      .map(
+        ([param, value]) =>
+          mechanisms.queryV2
+            ? [param, value].join('=') // v2 signing doesn't encode values in the signature calculation
+            : encodeURIComponent(param) + '=' + encodeURIComponent(value), // v4 signing requires the = be present even when there's no value
       )
       .sort()
-      .join('&')
-      .replace(/=(&|$)/g, ''); // remove trailing = for empty params
+      .join('&');
 
     const canonicalizedAmzHeaders = Object.keys(ctx.headers)
       .filter(headerName => headerName.startsWith('x-amz-'))
@@ -136,6 +141,7 @@ module.exports = () =>
           : ctx.method,
       contentMD5: ctx.get('Content-MD5'),
       contentType: ctx.get('Content-Type'),
+      headers: ctx.headers,
       timestamp: undefined,
       uri: canonicalizedResource,
       querystring: canonicalizedQueryString,
@@ -143,20 +149,22 @@ module.exports = () =>
     };
 
     // begin parsing for each part of the signature algorithm and the rest of the canonical request
-    let signature;
-    let signatureProvided;
+    let parseResult;
     if (mechanisms.header) {
-      const result = parseHeader(ctx.headers);
-      ({ signature, signatureProvided } = result);
+      parseResult = parseHeader(ctx.headers);
     } else if (mechanisms.queryV2) {
-      const result = parseQueryV2(ctx.query, ctx.headers);
-      ({ signature, signatureProvided } = result);
-      // S3 signing uses expiration time as timestamp
-      canonicalRequest.timestamp = result.expires;
+      parseResult = parseQueryV2(ctx.query, ctx.headers);
     } else if (mechanisms.queryV4) {
-      const result = parseQueryV4(ctx.query, ctx.headers);
-      ({ signature, signatureProvided } = result);
-      canonicalRequest.timestamp = result.timestamp;
+      parseResult = parseQueryV4(ctx.query, ctx.headers);
+    }
+
+    const { signature, signatureProvided } = parseResult;
+
+    if (signature.version === 2) {
+      // S3 signing uses expiration time as timestamp
+      canonicalRequest.timestamp = parseResult.expires;
+    } else if (signature.version === 4) {
+      canonicalRequest.timestamp = parseResult.timestamp;
     }
 
     let stringToSign;
@@ -170,10 +178,10 @@ module.exports = () =>
     }
 
     if (signature.version === 2) {
-      stringToSign = getStringToSign(canonicalRequest);
+      stringToSign = getStringToSignV2(canonicalRequest);
 
       const signingKey = account.accessKeys.get(signature.accessKeyId);
-      const calculatedSignature = calculateSignature(
+      const calculatedSignature = calculateSignatureV2(
         stringToSign,
         signingKey,
         signature.algorithm,
@@ -182,8 +190,19 @@ module.exports = () =>
         ctx.state.account = account;
       }
     } else if (signature.version === 4) {
-      // Signature version 4 calculation is unimplemeneted
-      ctx.state.account = account;
+      stringToSign = getStringToSignV4(canonicalRequest, signature);
+
+      const secretKey = account.accessKeys.get(signature.accessKeyId);
+      const calculatedSignature = calculateSignatureV4(
+        stringToSign,
+        secretKey,
+        signature.credential.date,
+        signature.credential.region,
+        signature.credential.service,
+      );
+      if (signatureProvided === calculatedSignature) {
+        ctx.state.account = account;
+      }
     }
 
     if (!ctx.state.account) {
@@ -315,7 +334,14 @@ function parseHeader(headers) {
 
     // skip verification of each authorization header component
 
-    signature.accessKeyId = componentMap.get('Credential').split('/')[0];
+    const [accessKeyId, date, region, service, termination] = componentMap
+      .get('Credential')
+      .split('/');
+
+    signature.accessKeyId = accessKeyId;
+    signature.credential = { date, region, service, termination };
+    signature.signedHeaders = componentMap.get('SignedHeaders').split(';');
+
     signatureProvided = componentMap.get('Signature');
   }
 
@@ -415,7 +441,14 @@ function parseQueryV4(query) {
         'X-Amz-SignedHeaders, and X-Amz-Expires parameters.',
     );
   }
-  signature.accessKeyId = query['X-Amz-Credential'].split('/')[0];
+  const [accessKeyId, date, region, service, termination] = query[
+    'X-Amz-Credential'
+  ].split('/');
+
+  signature.accessKeyId = accessKeyId;
+  signature.credential = { date, region, service, termination };
+  signature.signedHeaders = query['X-Amz-SignedHeaders'].split(';');
+
   const signatureProvided = query['X-Amz-Signature'];
 
   const timestamp = query['X-Amz-Date'];
@@ -464,22 +497,60 @@ function parseQueryV4(query) {
 }
 
 /**
- * Generates a string to be signed for the specified signature version.
- *
- * (currently only generates strings for V2 signing)
+ * Generates a string to be signed for signature version 2.
  *
  * @param {*} canonicalRequest
  */
-function getStringToSign(canonicalRequest) {
+function getStringToSignV2(canonicalRequest) {
+  const queryString = canonicalRequest.querystring.replace(/=(&|$)/g, ''); // remove trailing = for empty params
+
   return [
     canonicalRequest.method,
     canonicalRequest.contentMD5,
     canonicalRequest.contentType,
     canonicalRequest.timestamp,
     ...canonicalRequest.amzHeaders,
-    canonicalRequest.querystring
-      ? `${canonicalRequest.uri}?${canonicalRequest.querystring}`
+    queryString
+      ? `${canonicalRequest.uri}?${queryString}`
       : canonicalRequest.uri,
+  ].join('\n');
+}
+
+/**
+ * Generates a string to be signed for signature version 4.
+ *
+ * @param {*} canonicalRequest
+ * @param {*} signature
+ */
+function getStringToSignV4(canonicalRequest, { credential, signedHeaders }) {
+  const canonicalHeaders = signedHeaders
+    .map(header => `${header}:${canonicalRequest.headers[header]}\n`)
+    .join('');
+
+  const contentHash =
+    canonicalRequest.headers['x-amz-content-sha256'] || 'UNSIGNED-PAYLOAD';
+
+  const canonicalRequestString = [
+    canonicalRequest.method,
+    canonicalRequest.uri,
+    canonicalRequest.querystring,
+    canonicalHeaders,
+    signedHeaders.join(';'),
+    contentHash,
+  ].join('\n');
+
+  return [
+    'AWS4-HMAC-SHA256',
+    canonicalRequest.timestamp,
+    [
+      credential.date,
+      credential.region,
+      credential.service,
+      credential.termination,
+    ].join('/'),
+    createHash('sha256')
+      .update(canonicalRequestString)
+      .digest('hex'),
   ].join('\n');
 }
 
@@ -488,11 +559,43 @@ function getStringToSign(canonicalRequest) {
  * algorithm.
  *
  * @param {String} stringToSign the string representation of a canonical request
- * @param {String} signingKey a secret access key for V2 signing, or a signing key for V4 signing
+ * @param {String} signingKey a secret access key
  * @param {String} algorithm should be one of "sha1" or "sha256"
  */
-function calculateSignature(stringToSign, signingKey, algorithm) {
+function calculateSignatureV2(stringToSign, signingKey, algorithm) {
   const signature = createHmac(algorithm, signingKey);
   signature.update(stringToSign, 'utf8');
   return signature.digest('base64');
+}
+
+/**
+ * Performs the calculation of an authentication code for a string using the specified key and
+ * various components required by v4.
+ *
+ * @param {String} stringToSign the string representation of a canonical request
+ * @param {String} secretKey a secret access key
+ * @param {String} date received from the credential header
+ * @param {String} region received From the credential header
+ * @param {String} service received From the credential header
+ */
+function calculateSignatureV4(stringToSign, secretKey, date, region, service) {
+  const dateKey = createHmac('sha256', 'AWS4' + secretKey)
+    .update(date)
+    .digest();
+
+  const regionKey = createHmac('sha256', dateKey)
+    .update(region)
+    .digest();
+
+  const serviceKey = createHmac('sha256', regionKey)
+    .update(service)
+    .digest();
+
+  const signingKey = createHmac('sha256', serviceKey)
+    .update('aws4_request')
+    .digest();
+
+  return createHmac('sha256', signingKey)
+    .update(stringToSign)
+    .digest('hex');
 }

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -42,8 +42,7 @@ const SUBRESOURCES = {
 /**
  * Middleware that verifies signed HTTP requests
  *
- * This also processes request and response headers specified via query params. Currently only S3
- * (V2) signatures are fully supported. V4 signatures have incomplete support.
+ * This also processes request and response headers specified via query params.
  *
  * {@link https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html}
  */
@@ -108,20 +107,39 @@ module.exports = () =>
       .map(encodeURIComponentRFC3986)
       .join('/');
 
+    // begin parsing for each part of the signature algorithm and the rest of the canonical request
+    let parseResult;
+    if (mechanisms.header) {
+      parseResult = parseHeader(ctx.headers);
+    } else if (mechanisms.queryV2) {
+      parseResult = parseQueryV2(ctx.query, ctx.headers);
+    } else if (mechanisms.queryV4) {
+      parseResult = parseQueryV4(ctx.query, ctx.headers);
+    }
+    const { signature, signatureProvided } = parseResult;
+
     const canonicalizedQueryString = Object.entries(ctx.query)
-      .filter(
-        ([param]) =>
+      .filter(([param]) => {
+        if (
+          mechanisms.queryV2 &&
+          ['Signature', 'AWSAccessKeyId', 'Expires'].includes(param)
+        ) {
+          return false;
+        }
+        if (mechanisms.queryV4 && param === 'X-Amz-Signature') {
+          return false;
+        }
+        return (
+          signature.version !== 2 ||
           SUBRESOURCES[param] ||
-          RESPONSE_HEADERS[param] ||
-          (mechanisms.queryV4 &&
-            param.startsWith('X-Amz-') &&
-            param !== 'X-Amz-Signature'),
-      )
+          RESPONSE_HEADERS[param]
+        );
+      })
       .map(
         ([param, value]) =>
-          mechanisms.queryV2
-            ? [param, value].join('=') // v2 signing doesn't encode values in the signature calculation
-            : encodeURIComponent(param) + '=' + encodeURIComponent(value), // v4 signing requires the = be present even when there's no value
+          signature.version === 2
+            ? [param, value].slice(0, value ? 2 : 1).join('=') // v2 signing doesn't encode values in the signature calculation
+            : [param, value].map(encodeURIComponent).join('='), // v4 signing requires the = be present even when there's no value
       )
       .sort()
       .join('&');
@@ -147,18 +165,6 @@ module.exports = () =>
       querystring: canonicalizedQueryString,
       amzHeaders: canonicalizedAmzHeaders,
     };
-
-    // begin parsing for each part of the signature algorithm and the rest of the canonical request
-    let parseResult;
-    if (mechanisms.header) {
-      parseResult = parseHeader(ctx.headers);
-    } else if (mechanisms.queryV2) {
-      parseResult = parseQueryV2(ctx.query, ctx.headers);
-    } else if (mechanisms.queryV4) {
-      parseResult = parseQueryV4(ctx.query, ctx.headers);
-    }
-
-    const { signature, signatureProvided } = parseResult;
 
     if (signature.version === 2) {
       // S3 signing uses expiration time as timestamp
@@ -502,16 +508,14 @@ function parseQueryV4(query) {
  * @param {*} canonicalRequest
  */
 function getStringToSignV2(canonicalRequest) {
-  const queryString = canonicalRequest.querystring.replace(/=(&|$)/g, ''); // remove trailing = for empty params
-
   return [
     canonicalRequest.method,
     canonicalRequest.contentMD5,
     canonicalRequest.contentType,
     canonicalRequest.timestamp,
     ...canonicalRequest.amzHeaders,
-    queryString
-      ? `${canonicalRequest.uri}?${queryString}`
+    canonicalRequest.querystring
+      ? `${canonicalRequest.uri}?${canonicalRequest.querystring}`
       : canonicalRequest.uri,
   ].join('\n');
 }
@@ -527,6 +531,8 @@ function getStringToSignV4(canonicalRequest, { credential, signedHeaders }) {
     .map(header => `${header}:${canonicalRequest.headers[header]}\n`)
     .join('');
 
+  // skip computing content sha
+  // TODO: support staging, verifying, and committing content within store interface
   const contentHash =
     canonicalRequest.headers['x-amz-content-sha256'] || 'UNSIGNED-PAYLOAD';
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -50,7 +50,7 @@ exports.createServerAndClient = async function createServerAndClient(options) {
     endpoint: `http://localhost:${port}`,
     sslEnabled: false,
     s3ForcePathStyle: true,
-    signatureVersion: 'v2',
+    signatureVersion: 'v4',
   });
 
   return { s3rver, s3Client };

--- a/test/middleware/website.spec.js
+++ b/test/middleware/website.spec.js
@@ -234,7 +234,6 @@ describe('Static Website Tests', function() {
       'content-type',
       'text/html; charset=utf-8',
     );
-    console.log(res.body);
     expect(res.body).to.contain.string('Key: page/not-exists/index.html');
   });
 


### PR DESCRIPTION
- Implement v4 signing algorithm, minor code changes necessary to extract relevant data from the request
- Fixed failing CORS OPTIONS request when using signed headers (I think OPTIONS should not be verified at all, since it's a different HTTP method so would definitely result in a different signature).
- Resolved small issue when calculating the canonical query string regarding params with no value (v2 does not require the = to be present, v4 does), so I moved that stripping code into the v2-specific code path
- Added unit tests for incorrect v4 signatures when using headers as well as using query params
- Confirmed locally that signed GET and PUT requests work correctly, including CORS, from my web app
- Confirmed locally that corrupting a signed URL results in a 403

Fixes #659 