### PR TITLE
fix: support SPA routing to root index page

### DIFF
--- a/lib/middleware/website.js
+++ b/lib/middleware/website.js
@@ -64,7 +64,7 @@ exports = module.exports = () =>
     }
 
     try {
-      if (ctx.path.slice(1 + ctx.params.bucket.length) === '/') {
+      if (!ctx.params.key) {
         throw new S3Error('NoSuchKey', '', { Key: '' });
       }
       await next();
@@ -72,51 +72,51 @@ exports = module.exports = () =>
       if (err.code !== 'NoSuchKey') throw err;
 
       const key = err.detail.Key;
+      const indexDocumentPrefix =
+        key === '' || key.endsWith('/') ? key : key + '/';
+      const indexExists = await ctx.store.existsObject(
+        ctx.params.bucket,
+        indexDocumentPrefix + config.indexDocumentSuffix,
+      );
 
-      if (config.routingRules) {
-        for (const routingRule of config.routingRules) {
-          // Only 404s are supported for RoutingRules right now, this may be a deviation from S3 behaviour but we don't
-          // have a reproduction of a scenario where S3 does a redirect on a status code other than 404. If you're
-          // reading this comment and you have a use-case, please raise an issue with details of your scenario. Thanks!
-          if (routingRule.shouldRedirect(key, 404)) {
-            const location = routingRule.getRedirectLocation(key, {
-              protocol: ctx.protocol,
-              hostname: ctx.state.vhost
-                ? ctx.host
-                : `${ctx.host}/${ctx.params.bucket}`,
-            });
-
-            ctx.status = routingRule.statusCode;
-            ctx.redirect(location);
-            return;
+      if (indexExists) {
+        if (key !== indexDocumentPrefix) {
+          // Redirect keys that do not have a trailing slash when an index document exists
+          if (ctx.state.vhost) {
+            ctx.redirect(`/${key}/`);
+          } else {
+            // This isn't possible on real S3, but for convenience this allows website
+            // redirects without setting up virtual hosts
+            ctx.redirect(`/${ctx.params.bucket}/${key}/`);
           }
-        }
-      }
-
-      if (key === '' || key.endsWith('/')) {
-        ctx.params = {
-          ...ctx.params,
-          key: key + config.indexDocumentSuffix,
-        };
-        await getObject(ctx);
-      } else {
-        // Redirect keys that do not have a trailing slash when an index document exists
-        const indexExists = await ctx.store.existsObject(
-          ctx.params.bucket,
-          `${key}/${config.indexDocumentSuffix}`,
-        );
-        if (!indexExists) {
-          err.detail.Key = `${key}/${config.indexDocumentSuffix}`;
-          throw err;
-        }
-        if (ctx.state.vhost) {
-          ctx.redirect(`/${key}/`);
         } else {
-          // This isn't possible on real S3, but for convenience this allows website
-          // redirects without setting up virtual hosts
-          ctx.redirect(`/${ctx.params.bucket}/${key}/`);
+          ctx.params = {
+            ...ctx.params,
+            key: indexDocumentPrefix + config.indexDocumentSuffix,
+          };
+          await getObject(ctx);
         }
-        return;
+      } else {
+        // Only 404s are supported for RoutingRules right now, this may be a deviation from S3 behaviour but we don't
+        // have a reproduction of a scenario where S3 does a redirect on a status code other than 404. If you're
+        // reading this comment and you have a use-case, please raise an issue with details of your scenario. Thanks!
+        const routingRule = (config.routingRules || []).find(rule =>
+          rule.shouldRedirect(key, 404),
+        );
+        if (!routingRule) {
+          throw new S3Error('NoSuchKey', 'The specified key does not exist.', {
+            Key: indexDocumentPrefix + config.indexDocumentSuffix,
+          });
+        }
+        const location = routingRule.getRedirectLocation(key, {
+          protocol: ctx.protocol,
+          hostname: ctx.state.vhost
+            ? ctx.host
+            : `${ctx.host}/${ctx.params.bucket}`,
+        });
+
+        ctx.status = routingRule.statusCode;
+        ctx.redirect(location);
       }
     } finally {
       const objectRedirectLocation = ctx.response.get(

--- a/test/fixtures/website-test2.xml
+++ b/test/fixtures/website-test2.xml
@@ -11,5 +11,14 @@
                 <ReplaceKeyPrefixWith>replacement/</ReplaceKeyPrefixWith>
             </Redirect>
         </RoutingRule>
+        <RoutingRule>
+            <Condition>
+                <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals>
+            </Condition>
+            <Redirect>
+                <!-- this will redirect loop when no recursive/index.html is stored -->
+                <ReplaceKeyPrefixWith>recursive/</ReplaceKeyPrefixWith>
+            </Redirect>
+        </RoutingRule>
     </RoutingRules>
 </WebsiteConfiguration>

--- a/test/middleware/website.spec.js
+++ b/test/middleware/website.spec.js
@@ -348,6 +348,22 @@ describe('Static Website Tests', function() {
       );
     });
 
+    it('does not evaluate routing rules for an index page', async function() {
+      const expectedBody = '<html><body>Hello</body></html>';
+      await s3Client
+        .putObject({
+          Bucket: 'website2',
+          Key: 'recursive/foo/index.html',
+          Body: expectedBody,
+        })
+        .promise();
+      const res = await request('website2/recursive/foo', {
+        baseUrl: s3Client.config.endpoint,
+        headers: { accept: 'text/html' },
+      });
+      expect(res.body).to.equal(expectedBody);
+    });
+
     it('evaluates a multi-rule config', async function() {
       let res;
       try {

--- a/test/middleware/website.spec.js
+++ b/test/middleware/website.spec.js
@@ -216,6 +216,26 @@ describe('Static Website Tests', function() {
       'content-type',
       'text/html; charset=utf-8',
     );
+    expect(res.body).to.contain.string('Key: page/not-exists');
+  });
+
+  it('returns a HTML 404 error page for a missing index key', async function () {
+    let res;
+    try {
+      res = await request('website0/page/not-exists/', {
+        baseUrl: s3Client.config.endpoint,
+        headers: { accept: 'text/html' },
+      });
+    } catch (err) {
+      res = err.response;
+    }
+    expect(res.statusCode).to.equal(404);
+    expect(res.headers).to.have.property(
+      'content-type',
+      'text/html; charset=utf-8',
+    );
+    console.log(res.body);
+    expect(res.body).to.contain.string('Key: page/not-exists/index.html');
   });
 
   it('serves a custom error page if it exists', async function() {
@@ -333,7 +353,7 @@ describe('Static Website Tests', function() {
     it('evaluates a single simple routing rule', async function() {
       let res;
       try {
-        res = await request(`website2/test/key`, {
+        res = await request(`website2/test/key/`, {
           baseUrl: s3Client.config.endpoint,
           headers: { accept: 'text/html' },
           followRedirect: false,
@@ -344,7 +364,7 @@ describe('Static Website Tests', function() {
       expect(res.statusCode).to.equal(301);
       expect(res.headers).to.have.property(
         'location',
-        s3Client.config.endpoint + '/website2/replacement/key',
+        s3Client.config.endpoint + '/website2/replacement/key/',
       );
     });
 
@@ -357,14 +377,37 @@ describe('Static Website Tests', function() {
           Body: expectedBody,
         })
         .promise();
-      const res = await request('website2/recursive/foo', {
+      const res = await request('website2/recursive/foo/', {
         baseUrl: s3Client.config.endpoint,
         headers: { accept: 'text/html' },
       });
       expect(res.body).to.equal(expectedBody);
     });
 
-    it('evaluates a multi-rule config', async function() {
+    it('does not evaluate routing rules for an index page redirect', async function() {
+      const expectedBody = '<html><body>Hello</body></html>';
+      await s3Client
+        .putObject({
+          Bucket: 'website2',
+          Key: 'recursive/foo/index.html',
+          Body: expectedBody,
+        })
+        .promise();
+      let res;
+      try {
+        res = await request('website2/recursive/foo', {
+          baseUrl: s3Client.config.endpoint,
+          headers: { accept: 'text/html' },
+          followRedirect: false,
+        });
+      } catch (err) {
+        res = err.response;
+      }
+      expect(res.statusCode).to.equal(302);
+      expect(res.headers).to.have.property('location', '/website2/recursive/foo/');
+    });
+
+    it('evaluates a multi-rule config', async function () {
       let res;
       try {
         res = await request(`website3/simple/key`, {


### PR DESCRIPTION
Supersedes #574

The fix was essentially just to check if an index document exists at the current key. The diff ended up being noisier than I anticipated since the behavior extends to keys with or without a trailing slash.