### PR TITLE
fix: properly close write stream when object content is a buffer

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -290,7 +290,7 @@ class FilesystemStore {
       const md5Context = crypto.createHash('md5');
 
       if (Buffer.isBuffer(object.content)) {
-        writeStream.write(object.content);
+        writeStream.end(object.content);
         md5Context.update(object.content);
         resolve([object.content.length, md5Context.digest('hex')]);
       } else {

--- a/test/controllers/object.spec.js
+++ b/test/controllers/object.spec.js
@@ -360,6 +360,7 @@ describe('Operations on Objects', () => {
         '<Condition>Bucket POST must be of the enclosure-type multipart/form-data</Condition>',
       );
     });
+
     it('stores a text object without filename part metadata', async function() {
       const form = new FormData();
       form.append('key', 'text');


### PR DESCRIPTION
This fixes the Windows test suite finally. Surprisingly, it only took a single line change!