### PR TITLE
feat(object): add basic support for storage classes

### DIFF
--- a/lib/models/object.js
+++ b/lib/models/object.js
@@ -2,11 +2,21 @@
 
 const { pick, pickBy } = require('lodash');
 
+const S3Error = require('./error');
+
 class S3Object {
   constructor(bucket, key, content, metadata) {
     this.bucket = bucket;
     this.key = key;
     this.content = content;
+    if ('x-amz-storage-class' in metadata) {
+      if (!S3Object.STORAGE_CLASSES.includes(metadata['x-amz-storage-class'])) {
+        throw new S3Error(
+          'InvalidStorageClass',
+          'The storage class you specified is not valid',
+        );
+      }
+    }
     this.metadata = pick(metadata, [
       ...S3Object.ALLOWED_METADATA,
 
@@ -39,6 +49,17 @@ S3Object.ALLOWED_METADATA = [
   'content-language',
   'content-type',
   'expires',
+  'x-amz-storage-class',
   'x-amz-website-redirect-location',
+];
+S3Object.STORAGE_CLASSES = [
+  'STANDARD',
+  'REDUCED_REDUNDANCY',
+  'STANDARD_IA',
+  'ONEZONE_IA',
+  'INTELLIGENT_TIERING',
+  'GLACIER',
+  'DEEP_ARCHIVE',
+  'OUTPOSTS',
 ];
 module.exports = S3Object;

--- a/test/controllers/object.spec.js
+++ b/test/controllers/object.spec.js
@@ -858,6 +858,43 @@ describe('Operations on Objects', () => {
         .putObject({ Bucket: bucket, Key: 'foo2.txt', Body: 'Hello2!' })
         .promise();
     });
+
+    it('stores an object with a storage class', async function () {
+      await s3Client
+        .putObject({
+          Bucket: 'bucket-a',
+          Key: 'somekey',
+          Body: 'Hello!',
+          StorageClass: 'STANDARD_IA',
+        })
+        .promise();
+      const object = await s3Client
+        .getObject({
+          Bucket: 'bucket-a',
+          Key: 'somekey',
+        })
+        .promise();
+      expect(object.ETag).to.equal(JSON.stringify(md5('Hello!')));
+      expect(object.StorageClass).to.equal('STANDARD_IA');
+    });
+
+    it('fails to store an object with an invalid storage class', async function () {
+      let error;
+      try {
+        await s3Client
+          .putObject({
+            Bucket: 'bucket-a',
+            Key: 'somekey',
+            Body: 'Hello!',
+            StorageClass: 'BAD_STORAGE',
+          })
+          .promise();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.exist;
+      expect(error.code).to.equal('InvalidStorageClass');
+    });
   });
 
   describe('PUT Object - Copy', () => {


### PR DESCRIPTION
Fixes #727. No additional validation is performed beyond checking that the provided storage class value is allowed.