### PR TITLE
fix(object): Takes into account the range of bytes starting with 0

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -259,7 +259,7 @@ class FilesystemStore {
       if (range.start < 0 || Math.min(range.end, lastByte) < range.start) {
         // the range is not satisfiable
         const object = new S3Object(bucket, key, null, metadata);
-        if (options && (options.start || options.end)) {
+        if (options && (options.start !== undefined || options.end)) {
           object.range = range;
         }
         return object;
@@ -274,7 +274,7 @@ class FilesystemStore {
           .on('open', () => resolve(stream));
       });
       const object = new S3Object(bucket, key, content, metadata);
-      if (options && (options.start || options.end)) {
+      if (options && (options.start !== undefined || options.end)) {
         object.range = range;
       }
       return object;


### PR DESCRIPTION
Fixes returning the `Range-Content` header when requesting a range starting with byte 0 and no end, ie `bytes=0-`

The issue has been reported here: https://github.com/jamhall/s3rver/issues/754