### PR TITLE
fix(object): Takes into account the range of bytes starting with 0

### DIFF
--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -16,7 +16,7 @@ const { format } = require('util');
 const { getConfigModel } = require('../models/config');
 const S3Bucket = require('../models/bucket');
 const S3Object = require('../models/object');
-const { concatStreams, walk } = require('../utils');
+const { concatStreams, walk, ensureDir } = require('../utils');
 
 const S3RVER_SUFFIX = '%s._S3rver_%s';
 
@@ -45,14 +45,6 @@ class FilesystemStore {
   // helpers
   getBucketPath(bucketName) {
     return path.join(this.rootDirectory, bucketName);
-  }
-
-  async makeBucketDirIfNotExists(bucketPath) {
-    const options = { recursive: true, mode: 0o0755 };
-    if (process.platform === 'win32') {
-      delete options.mode;
-    }
-    await fs.mkdir(bucketPath, options);
   }
 
   getResourcePath(bucket, key = '', resource) {
@@ -145,7 +137,7 @@ class FilesystemStore {
 
   async putBucket(bucket) {
     const bucketPath = this.getBucketPath(bucket);
-    await this.makeBucketDirIfNotExists(bucketPath);
+    await ensureDir(bucketPath);
     return this.getBucket(bucket);
   }
 
@@ -298,7 +290,7 @@ class FilesystemStore {
       'object',
     );
 
-    await this.makeBucketDirIfNotExists(path.dirname(objectPath));
+    await ensureDir(path.dirname(objectPath));
 
     const [size, md5] = await new Promise((resolve, reject) => {
       const writeStream = createWriteStream(objectPath);
@@ -342,7 +334,7 @@ class FilesystemStore {
     const destObjectPath = this.getResourcePath(destBucket, destKey, 'object');
 
     if (srcObjectPath !== destObjectPath) {
-      await this.makeBucketDirIfNotExists(path.dirname(destObjectPath));
+      await ensureDir(path.dirname(destObjectPath));
       await fs.copyFile(srcObjectPath, destObjectPath);
     }
 
@@ -398,7 +390,7 @@ class FilesystemStore {
       uploadId,
     );
 
-    await this.makeBucketDirIfNotExists(uploadDir);
+    await ensureDir(uploadDir);
 
     await Promise.all([
       fs.writeFile(path.join(uploadDir, 'key'), key),
@@ -413,7 +405,7 @@ class FilesystemStore {
       partNumber.toString(),
     );
 
-    await this.makeBucketDirIfNotExists(path.dirname(partPath));
+    await ensureDir(path.dirname(partPath));
 
     const [size, md5] = await new Promise((resolve, reject) => {
       const writeStream = createWriteStream(partPath);

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -43,22 +43,16 @@ class FilesystemStore {
   }
 
   // helpers
-
   getBucketPath(bucketName) {
     return path.join(this.rootDirectory, bucketName);
   }
 
   async makeBucketDirIfNotExists(bucketPath) {
-    let exists = false;
-    try {
-      await fs.access(bucketPath, fs.constants.F_OK);
-    } catch (ex) {
-      exists = true;
+    const options = { recursive: true, mode: 0o0755 };
+    if (process.platform === 'win32') {
+      delete options.mode;
     }
-
-    if (!exists) {
-      await fs.mkdir(bucketPath, 0o0755, { recursive: true });
-    }
+    await fs.mkdir(bucketPath, options);
   }
 
   getResourcePath(bucket, key = '', resource) {

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -259,7 +259,7 @@ class FilesystemStore {
       if (range.start < 0 || Math.min(range.end, lastByte) < range.start) {
         // the range is not satisfiable
         const object = new S3Object(bucket, key, null, metadata);
-        if (options && (options.start || options.end)) {
+        if (options && (options.start !== undefined || options.end)) {
           object.range = range;
         }
         return object;
@@ -274,7 +274,7 @@ class FilesystemStore {
           .on('open', () => resolve(stream));
       });
       const object = new S3Object(bucket, key, content, metadata);
-      if (options && (options.start || options.end)) {
+      if (options && (options.start !== undefined || options.end)) {
         object.range = range;
       }
       return object;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const xmlParser = require('fast-xml-parser');
 const fs = require('fs');
+const fsPromises = require('fs/promises');
 const he = require('he');
 const path = require('path');
 const { PassThrough } = require('stream');
@@ -172,4 +173,12 @@ exports.utf8BodyParser = async function (ctx) {
     req.on('end', () => resolve(payload));
     req.on('error', reject);
   });
+};
+
+exports.ensureDir = async function (dirPath) {
+  const options = { recursive: true, mode: 0o0755 };
+  if (process.platform === 'win32') {
+    delete options.mode;
+  }
+  await fsPromises.mkdir(dirPath, options);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,6 @@
 const crypto = require('crypto');
 const xmlParser = require('fast-xml-parser');
 const fs = require('fs');
-const fsPromises = require('fs/promises');
 const he = require('he');
 const path = require('path');
 const { PassThrough } = require('stream');
@@ -180,5 +179,5 @@ exports.ensureDir = async function (dirPath) {
   if (process.platform === 'win32') {
     delete options.mode;
   }
-  await fsPromises.mkdir(dirPath, options);
+  await fs.promises.mkdir(dirPath, options);
 };


### PR DESCRIPTION
Fixes errors when trying to re-create directories that already exist.

Uses a helper function to verify for the directory existence first.

Note this PR also includes the fix for `options.start !== undefined` as I've built on top of my previous branch.