### PR TITLE
docs: option address, not hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ let instance;
 before(function (done) {
   instance = new S3rver({
     port: 4569,
-    hostname: 'localhost',
+    address: 'localhost',
     silent: false,
     directory: '/tmp/s3rver_test_directory',
   }).run(done);


### PR DESCRIPTION
The field is `address` in the code, not `hostname`. Setting `hostname` has no effect.

See: https://github.com/jamhall/s3rver/blob/main/lib/s3rver.js#L146