### PR TITLE
add operation to abort multipart upload

### DIFF
--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -803,3 +803,20 @@ exports.uploadPartCopy = async function uploadPartCopy(ctx) {
     throw err;
   }
 };
+
+/**
+ * Abort Multipart Upload
+ * This action aborts a multipart upload. After a multipart upload is aborted,
+ * no additional parts can be uploaded using that upload ID. The storage
+ * consumed by any previously uploaded parts will be freed.
+ * {@link https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html}
+ */
+exports.abortMultipartUpload = async function abortMultipartUpload(ctx) {
+  await ctx.store.abortUpload(
+    ctx.params.bucket,
+    ctx.params.key,
+    ctx.query.uploadId,
+    ctx.headers,
+  );
+  ctx.body = '';
+};

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -165,6 +165,8 @@ router
     switch (ctx.params.queryMethod) {
       case undefined:
         return objectCtrl.deleteObject(ctx);
+      case 'uploadId':
+        return objectCtrl.abortMultipartUpload(ctx);
       case 'tagging':
         throw new S3Error('NotImplemented');
       default:

--- a/lib/stores/filesystem.js
+++ b/lib/stores/filesystem.js
@@ -400,6 +400,15 @@ class FilesystemStore {
     ]);
   }
 
+  async abortUpload(bucket, key, uploadId, metadata) {
+    const uploadDir = path.join(
+      this.getResourcePath(bucket, undefined, 'uploads'),
+      uploadId,
+    );
+
+    await fs.rmdir(uploadDir, { recursive: true });
+  }
+
   async putPart(bucket, uploadId, partNumber, content) {
     const partPath = path.join(
       this.getResourcePath(bucket, undefined, 'uploads'),

--- a/test/controllers/object.spec.js
+++ b/test/controllers/object.spec.js
@@ -1377,7 +1377,7 @@ describe('Operations on Objects', () => {
     });
   });
 
-  describe('Initiate/Upload/Complete Multipart upload', () => {
+  describe('Initiate/Upload/Complete/Abort Multipart upload', () => {
     it('uploads a text file to a multi directory path', async function () {
       const data = await s3Client
         .putObject({
@@ -1553,6 +1553,22 @@ describe('Operations on Objects', () => {
         })
         .promise();
       expect(JSON.parse(data.CopyPartResult.ETag)).to.be.ok;
+    });
+
+    it('aborts a multipart upload', async function () {
+      const upload = await s3Client
+        .createMultipartUpload({
+          Bucket: 'bucket-a',
+          Key: 'destination',
+        })
+        .promise();
+      await s3Client
+        .abortMultipartUpload({
+          Bucket: 'bucket-a',
+          Key: 'desintation',
+          UploadId: upload.UploadId,
+        })
+        .promise();
     });
 
     it('fails to copy a part range for an out of bounds requests', async function () {


### PR DESCRIPTION
I have noted missing operation to abort multipart upload. That operation does not have response, so it's very easy to implement.