### PR TITLE
Add support for ${filename} in POST Object

### DIFF
--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -317,8 +317,10 @@ exports.postObject = async function postObject(ctx) {
           if (fieldname !== 'file' || fileCount++) {
             return file.resume();
           }
+          // S3 strips leading spaces from filename here, even though their docs
+          // don't mention it. I have raised this as an issue with AWS Enterprise support
           // eslint-disable-next-line no-template-curly-in-string
-          key = key.replace('${filename}', filename);
+          key = key.replace('${filename}', filename.replace(/^ +/, ''));
           resolve(new S3Object(ctx.params.bucket, key, file, metadata));
         };
 

--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -313,10 +313,11 @@ exports.postObject = async function postObject(ctx) {
               break;
           }
         };
-        const fileHandler = (fieldname, file) => {
+        const fileHandler = (fieldname, file, filename) => {
           if (fieldname !== 'file' || fileCount++) {
             return file.resume();
           }
+          key = key.replace('${filename}', filename);
           resolve(new S3Object(ctx.params.bucket, key, file, metadata));
         };
 

--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -410,7 +410,7 @@ exports.postObject = async function postObject(ctx) {
       if (!location.pathname.endsWith('/')) {
         location.pathname += '/';
       }
-      location.pathname += object.key;
+      location.pathname += encodeURIComponent(object.key);
       ctx.set('Location', location.href);
     }
 

--- a/lib/controllers/object.js
+++ b/lib/controllers/object.js
@@ -317,6 +317,7 @@ exports.postObject = async function postObject(ctx) {
           if (fieldname !== 'file' || fileCount++) {
             return file.resume();
           }
+          // eslint-disable-next-line no-template-curly-in-string
           key = key.replace('${filename}', filename);
           resolve(new S3Object(ctx.params.bucket, key, file, metadata));
         };

--- a/test/controllers/object.spec.js
+++ b/test/controllers/object.spec.js
@@ -378,7 +378,7 @@ describe('Operations on Objects', () => {
   describe('POST Object', () => {
     it('stores a text object for a multipart/form-data request', async function () {
       const form = new FormData();
-      form.append('key', 'text');
+      form.append('key', 'my_files/${filename}');
       form.append('file', 'Hello!', 'post_file.txt');
       const res = await request.post('bucket-a', {
         baseUrl: s3Client.endpoint.href,
@@ -387,7 +387,7 @@ describe('Operations on Objects', () => {
       });
       expect(res.statusCode).to.equal(204);
       const object = await s3Client
-        .getObject({ Bucket: 'bucket-a', Key: 'text' })
+        .getObject({ Bucket: 'bucket-a', Key: 'my_files/post_file.txt' })
         .promise();
       expect(object.ContentType).to.equal('binary/octet-stream');
       expect(object.Body).to.deep.equal(Buffer.from('Hello!'));


### PR DESCRIPTION
The S3 POST Object api allows Key to contain "`${filename}`" in order to use the client-provided filename to form part of the uploaded Object Key. (Notably, no escape mechanism is provided if you in fact wanted a Key containing `${filename}`.)

See https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html

This PR adds support for this feature in `s3rver`

Thanks for a great tool!


Rich
